### PR TITLE
Support `ForEach` iterating over multiple arrays at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.1.9
 
-* TODO
+* [#6](https://github.com/harrisont/fastbuild-vscode/issues/6) Support `ForEach` iterating over multiple arrays at a time (single array iterating already supported). This completes support for the full FASTBuild language.
 
 # v0.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.9
+
+* TODO
+
 # v0.1.8
 
 * Rename repository from `fbuild-vscode-lsp` to `fastbuild-vscode`.

--- a/README.md
+++ b/README.md
@@ -24,15 +24,12 @@ It does not yet provide syntax highlighting. For that in the meantime, I recomme
     * `#if exists(...)` ([docs](https://www.fastbuild.org/docs/syntaxguide.html#if)) always evaluates to false.
     * `#import` ([docs](https://www.fastbuild.org/docs/syntaxguide.html#import)) uses a placeholder value instead of reading the actual environement variable value.
 * Only evaluates user functions if they are called at least once. This means that you cannot jump to the definition of a variable defined inside a user function if that user function is never called, for example.
-* Note that some of the language is not yet implemented. See the [Support full FASTBuild syntax](https://github.com/harrisont/fastbuild-vscode/issues/6) issue for details.
 
 ## Compatibility
 
 Compatible with [FASTBuild](https://www.fastbuild.org/) version 1.08 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)).
 
 It may be compatible with a newer version of FASTBuild, but this was the latest version tested.
-
-Note that some of the language is not yet implemented. See the [Support full FASTBuild syntax](https://github.com/harrisont/fastbuild-vscode/issues/6) issue for details.
 
 ## Installing
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/evaluator.ts
+++ b/server/src/evaluator.ts
@@ -1148,8 +1148,8 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                         return new DataAndMaybeError(result, error);
                     }
 
-                    if ((iterators.length > 1) && (arrayItems.length != iterators[0].arrayItems.length)) {
-                        const error = new EvaluationError(arrayToLoopOverRange, `TODO`);
+                    if ((iterators.length > 0) && (arrayItems.length != iterators[0].arrayItems.length)) {
+                        const error = new EvaluationError(arrayToLoopOverRange, `'ForEach' Array variable to loop over contains ${arrayItems.length} elements, but the loop is for ${iterators[0].arrayItems.length} elements.`);
                         return new DataAndMaybeError(result, error);
                     }
 

--- a/server/src/evaluator.ts
+++ b/server/src/evaluator.ts
@@ -1119,59 +1119,83 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     );
                 }
             } else if (isParsedStatementForEach(statement)) {
-                // Evaluate the array to loop over.
-                const maybeArrayToLoopOver = statement.iterators[0].arrayToLoopOver;
-                if (maybeArrayToLoopOver.type !== 'evaluatedVariable') {
-                    const range = new SourceRange(context.thisFbuildUri, statement.range);
-                    const error = new InternalEvaluationError(range, `'ForEach' array to loop over must be an evaluated variable, but instead is '${maybeArrayToLoopOver.type}'`);
-                    return new DataAndMaybeError(result, error);
+                // Evaluate the iterators (array to loop over plus the loop-variable)
+                interface ForEachIterator {
+                    arrayItems: Value[];
+                    evaluatedLoopVarNameValue: string;
+                    loopVarRange: SourceRange;
+                    loopVarDefinition: VariableDefinition;
                 }
-                const arrayToLoopOver: ParsedEvaluatedVariable = maybeArrayToLoopOver;
-                const arrayToLoopOverRange = new SourceRange(context.thisFbuildUri, arrayToLoopOver.range);
-                const evaluatedArrayToLoopOverAndMaybeError = evaluateEvaluatedVariable(arrayToLoopOver, context);
-                const evaluatedArrayToLoopOver = evaluatedArrayToLoopOverAndMaybeError.data;
-                pushToFirstArray(result.evaluatedVariables, evaluatedArrayToLoopOver.evaluatedVariables);
-                pushToFirstArray(result.variableReferences, evaluatedArrayToLoopOver.variableReferences);
-                if (evaluatedArrayToLoopOverAndMaybeError.error !== null) {
-                    return new DataAndMaybeError(result, evaluatedArrayToLoopOverAndMaybeError.error);
-                }
+                const iterators: ForEachIterator[] = [];
+                for (const iterator of statement.iterators) {
+                    // Evaluate the array to loop over.
+                    if (iterator.arrayToLoopOver.type !== 'evaluatedVariable') {
+                        const range = new SourceRange(context.thisFbuildUri, statement.range);
+                        const error = new InternalEvaluationError(range, `'ForEach' array to loop over must be an evaluated variable, but instead is '${iterator.arrayToLoopOver.type}'`);
+                        return new DataAndMaybeError(result, error);
+                    }
+                    const arrayToLoopOverRange = new SourceRange(context.thisFbuildUri, iterator.arrayToLoopOver.range);
+                    const evaluatedArrayToLoopOverAndMaybeError = evaluateEvaluatedVariable(iterator.arrayToLoopOver, context);
+                    const evaluatedArrayToLoopOver = evaluatedArrayToLoopOverAndMaybeError.data;
+                    pushToFirstArray(result.evaluatedVariables, evaluatedArrayToLoopOver.evaluatedVariables);
+                    pushToFirstArray(result.variableReferences, evaluatedArrayToLoopOver.variableReferences);
+                    if (evaluatedArrayToLoopOverAndMaybeError.error !== null) {
+                        return new DataAndMaybeError(result, evaluatedArrayToLoopOverAndMaybeError.error);
+                    }
+                    const arrayItems = evaluatedArrayToLoopOver.valueScopeVariable.value;
+                    if (!(arrayItems instanceof Array)) {
+                        const error = new EvaluationError(arrayToLoopOverRange, `'ForEach' variable to loop over must be an Array, but instead is ${getValueTypeNameA(arrayItems)}`);
+                        return new DataAndMaybeError(result, error);
+                    }
 
-                const loopVar = statement.iterators[0].loopVar;
-                const loopVarRange = new SourceRange(context.thisFbuildUri, loopVar.range);
+                    if ((iterators.length > 1) && (arrayItems.length != iterators[0].arrayItems.length)) {
+                        const error = new EvaluationError(arrayToLoopOverRange, `TODO`);
+                        return new DataAndMaybeError(result, error);
+                    }
 
-                // Evaluate the loop-variable name.
-                const evaluatedLoopVarNameAndMaybeError = evaluateRValue(loopVar.name, context);
-                const evaluatedLoopVarName = evaluatedLoopVarNameAndMaybeError.data;
-                pushToFirstArray(result.evaluatedVariables, evaluatedLoopVarName.evaluatedVariables);
-                pushToFirstArray(result.variableReferences, evaluatedLoopVarName.variableReferences);
-                if (evaluatedLoopVarNameAndMaybeError.error !== null) {
-                    return new DataAndMaybeError(result, evaluatedLoopVarNameAndMaybeError.error);
+                    const loopVar = iterator.loopVar;
+                    const loopVarRange = new SourceRange(context.thisFbuildUri, loopVar.range);
+                    const loopVarDefinition = context.scopeStack.createVariableDefinition(loopVarRange);
+
+                    // Evaluate the loop-variable name.
+                    const evaluatedLoopVarNameAndMaybeError = evaluateRValue(loopVar.name, context);
+                    const evaluatedLoopVarName = evaluatedLoopVarNameAndMaybeError.data;
+                    pushToFirstArray(result.evaluatedVariables, evaluatedLoopVarName.evaluatedVariables);
+                    pushToFirstArray(result.variableReferences, evaluatedLoopVarName.variableReferences);
+                    if (evaluatedLoopVarNameAndMaybeError.error !== null) {
+                        return new DataAndMaybeError(result, evaluatedLoopVarNameAndMaybeError.error);
+                    }
+                    if (typeof evaluatedLoopVarName.value !== 'string') {
+                        const error = new InternalEvaluationError(loopVarRange, `Variable name must evaluate to a String, but instead evaluates to ${getValueTypeNameA(evaluatedLoopVarName.value)}`);
+                        return new DataAndMaybeError(result, error);
+                    }
+                    const evaluatedLoopVarNameValue: string = evaluatedLoopVarName.value;
+
+                    iterators.push({
+                        arrayItems,
+                        evaluatedLoopVarNameValue,
+                        loopVarRange,
+                        loopVarDefinition,
+                    });
                 }
-                if (typeof evaluatedLoopVarName.value !== 'string') {
-                    const error = new InternalEvaluationError(loopVarRange, `Variable name must evaluate to a String, but instead evaluates to ${getValueTypeNameA(evaluatedLoopVarName.value)}`);
-                    return new DataAndMaybeError(result, error);
-                }
-                const evaluatedLoopVarNameValue: string = evaluatedLoopVarName.value;
 
                 // Evaluate the function body.
 
-                const definition = context.scopeStack.createVariableDefinition(loopVarRange);
-                const arrayItems = evaluatedArrayToLoopOver.valueScopeVariable.value;
-                if (!(arrayItems instanceof Array)) {
-                    const error = new EvaluationError(arrayToLoopOverRange, `'ForEach' variable to loop over must be an Array, but instead is ${getValueTypeNameA(arrayItems)}`);
-                    return new DataAndMaybeError(result, error);
-                }
-
                 let error: Error | null = null;
-                for (const arrayItem of arrayItems) {
+                const arrayItemsLength = iterators[0].arrayItems.length;
+                for (let arrayItemIndex = 0; arrayItemIndex < arrayItemsLength; arrayItemIndex++) {
                     context.scopeStack.withScope(() => {
-                        const variable = context.scopeStack.setVariableInCurrentScope(evaluatedLoopVarNameValue, arrayItem, definition);
+                        // Set a variable in the current scope for each iterator's loop variable.
+                        for (const iterator of iterators) {
+                            const arrayItem = iterator.arrayItems[arrayItemIndex];
+                            const loopVariable = context.scopeStack.setVariableInCurrentScope(iterator.evaluatedLoopVarNameValue, arrayItem, iterator.loopVarDefinition);
 
-                        // The loop variable is a variable reference.
-                        result.variableReferences.push({
-                            definition: variable.definition,
-                            range: loopVarRange,
-                        });
+                            // The loop variable is a variable reference.
+                            result.variableReferences.push({
+                                definition: loopVariable.definition,
+                                range: iterator.loopVarRange,
+                            });
+                        }
 
                         const evaluatedStatementsAndMaybeError = evaluateStatements(statement.statements, context);
                         const evaluatedStatements = evaluatedStatementsAndMaybeError.data;

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -129,7 +129,7 @@ function assertEvaluationError(input: string, expectedErrorMessage: string, expe
         () => evaluateInput(input, enableDiagnostics),
         actualError => {
             assert.strictEqual(actualError.name, 'EvaluationError', `Expected an EvaluationError exception but got ${actualError}:\n\n${actualError.stack}`);
-            assert(actualError.message === expectedErrorMessage, `Got error message <${actualError.message}> but expected <${expectedErrorMessage}>`);
+            assert.strictEqual(actualError.message, expectedErrorMessage, `Error message was different than expected`);
             // Create a `ParseSourceRange` out of the `SourceRange` in order to drop the file URI.
             const actualRange = createParseRange(actualError.range.start.line, actualError.range.start.character, actualError.range.end.line, actualError.range.end.character);
             assert.deepStrictEqual(actualRange, expectedRange, `Expected the error range to be ${getParseSourceRangeString(expectedRange)} but it is ${getParseSourceRangeString(actualRange)}`);
@@ -2297,8 +2297,8 @@ describe('evaluator', () => {
                     .Combined = '$Item1$-$Item2$'
                 }
             `;
-            const expectedErrorMessage = `ForEach(): variable '.Options' contains 2 elements, but the loop is for 3 elements.`;
-            assertEvaluationError(input, expectedErrorMessage, createParseRange(3, 123, 3, 123));
+            const expectedErrorMessage = `'ForEach' Array variable to loop over contains 2 elements, but the loop is for 1 elements.`;
+            assertEvaluationError(input, expectedErrorMessage, createParseRange(3, 56, 3, 65));
         });
 
         it('body is on the same line', () => {

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -2253,7 +2253,7 @@ describe('evaluator', () => {
                 ForEach( .Item1 in .MyArray1,.Item2 in .MyArray2,
                          .Item3 in .MyArray3 )
                 {
-                    Print( .Item1, .Item2, .Item3 )
+                    .Combined = '$Item1$-$Item2$-$Item3$'
                 }
             `;
             assertEvaluatedVariablesValueEqual(input, [
@@ -2275,7 +2275,7 @@ describe('evaluator', () => {
                          .Item2 in .MyArray2
                          .Item3 in .MyArray3 )
                 {
-                    Print( .Item1, .Item2, .Item3 )
+                    .Combined = '$Item1$-$Item2$-$Item3$'
                 }
             `;
             assertEvaluatedVariablesValueEqual(input, [
@@ -2294,7 +2294,7 @@ describe('evaluator', () => {
                 .MyArray2 = {'a2', 'b2'}
                 ForEach( .Item1 in .MyArray1, .Item2 in .MyArray2 )
                 {
-                    Print( .Item1, .Item2 )
+                    .Combined = '$Item1$-$Item2$'
                 }
             `;
             const expectedErrorMessage = `ForEach(): variable '.Options' contains 2 elements, but the loop is for 3 elements.`;

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -2245,6 +2245,47 @@ describe('evaluator', () => {
             ]);
         });
 
+        it('iterates over multiple arrays at a time', () => {
+            const input = `
+                .MyArray1 = {'a1', 'b1', 'c1'}
+                .MyArray2 = {'a2', 'b2', 'c2'}
+                .MyArray3 = {'a3', 'b3', 'c3'}
+                ForEach( .Item1 in .MyArray1,
+                         .Item2 in .MyArray2
+                         .Item3 in .MyArray3 )
+                {
+                    Print( .Item1, .Item2, .Item3 )
+                }
+            `;
+            assertEvaluatedVariablesValueEqual(input, [
+                ['a1', 'b1', 'c1'],
+                ['a2', 'b2', 'c2'],
+                ['a3', 'b3', 'c3'],
+                'a1', 'a2', 'a3',
+                'b1', 'b2', 'b3',
+                'c1', 'c2', 'c3',
+            ]);
+        });
+
+        it('errors when iterating over multiple arrays with differnt sizes', () => {
+            const input = `
+                .MyArray1 = {'a1'}
+                .MyArray2 = {'a2', 'b2'}
+                ForEach( .Item1 in .MyArray1, .Item2 in .MyArray2 )
+                {
+                    Print( .Item1, .Item2 )
+                }
+            `;
+            assertEvaluatedVariablesValueEqual(input, [
+                ['a1', 'b1', 'c1'],
+                ['a2', 'b2', 'c2'],
+                ['a3', 'b3', 'c3'],
+                'a1', 'a2', 'a3',
+                'b1', 'b2', 'b3',
+                'c1', 'c2', 'c3',
+            ]);
+        });
+
         it('body is on the same line', () => {
             const input = `
                 .MyArray = {'a', 'b', 'c'}

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -2245,12 +2245,33 @@ describe('evaluator', () => {
             ]);
         });
 
-        it('iterates over multiple arrays at a time', () => {
+        it('iterates over multiple arrays (separated by commas) at a time', () => {
             const input = `
                 .MyArray1 = {'a1', 'b1', 'c1'}
                 .MyArray2 = {'a2', 'b2', 'c2'}
                 .MyArray3 = {'a3', 'b3', 'c3'}
-                ForEach( .Item1 in .MyArray1,
+                ForEach( .Item1 in .MyArray1,.Item2 in .MyArray2,
+                         .Item3 in .MyArray3 )
+                {
+                    Print( .Item1, .Item2, .Item3 )
+                }
+            `;
+            assertEvaluatedVariablesValueEqual(input, [
+                ['a1', 'b1', 'c1'],
+                ['a2', 'b2', 'c2'],
+                ['a3', 'b3', 'c3'],
+                'a1', 'a2', 'a3',
+                'b1', 'b2', 'b3',
+                'c1', 'c2', 'c3',
+            ]);
+        });
+
+        it('iterates over multiple arrays (separated by whitespace) at a time', () => {
+            const input = `
+                .MyArray1 = {'a1', 'b1', 'c1'}
+                .MyArray2 = {'a2', 'b2', 'c2'}
+                .MyArray3 = {'a3', 'b3', 'c3'}
+                ForEach( .Item1 in .MyArray1
                          .Item2 in .MyArray2
                          .Item3 in .MyArray3 )
                 {
@@ -2267,7 +2288,7 @@ describe('evaluator', () => {
             ]);
         });
 
-        it('errors when iterating over multiple arrays with differnt sizes', () => {
+        it('errors when iterating over multiple arrays with different sizes', () => {
             const input = `
                 .MyArray1 = {'a1'}
                 .MyArray2 = {'a2', 'b2'}
@@ -2276,14 +2297,8 @@ describe('evaluator', () => {
                     Print( .Item1, .Item2 )
                 }
             `;
-            assertEvaluatedVariablesValueEqual(input, [
-                ['a1', 'b1', 'c1'],
-                ['a2', 'b2', 'c2'],
-                ['a3', 'b3', 'c3'],
-                'a1', 'a2', 'a3',
-                'b1', 'b2', 'b3',
-                'c1', 'c2', 'c3',
-            ]);
+            const expectedErrorMessage = `ForEach(): variable '.Options' contains 2 elements, but the loop is for 3 elements.`;
+            assertEvaluationError(input, expectedErrorMessage, createParseRange(3, 123, 3, 123));
         });
 
         it('body is on the same line', () => {
@@ -2299,7 +2314,7 @@ describe('evaluator', () => {
             ]);
         });
 
-        it('Loop variable must be an array', () => {
+        it('errors if the loop variable is not an array', () => {
             const input = `
                 .MyArray = 123
                 ForEach( .Item in .MyArray )


### PR DESCRIPTION
Support `ForEach` iterating over multiple arrays at a time (single array iterating already supported).

This completes support for the full FASTBuild language.
Fixes #6.