### PR TITLE
Evaluate variable definitions' LHS after assignment/modification, to support hovering it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.0
+
+## New Features
+
+* You can now hover over the left-hand side of a variable assignment or modification to see the variable's new value.
+
 # v0.2.2
 
 * Distinguish between targets and variables in the symbol listing.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -2830,152 +2830,140 @@ describe('evaluator', () => {
             describe('boolean', () => {
                 it('"{true-literal} == {true-literal}" evaluates to true', () => {
                     const input = `
-                        .Result = false
                         If( true == true )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true]);
                 });
 
                 it('"{true-literal} == {false-literal}" evaluates to false', () => {
                     const input = `
-                        .Result = false
                         If( true == false )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false]);
+                    assertEvaluatedVariablesValueEqual(input, []);
                 });
 
                 it('"true == {true-literal}" evaluates to true', () => {
                     const input = `
                         .Value1 = true
-                        .Result = false
                         If( .Value1 == true )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [true, false, true, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true, true, true]);
                 });
 
                 it('"{true-literal} == true" evaluates to true', () => {
                     const input = `
                         .Value1 = true
-                        .Result = false
                         If( true == .Value1 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [true, false, true, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true, true, true]);
                 });
 
                 it('"true == true" evaluates to true', () => {
                     const input = `
                         .Value1 = true
                         .Value2 = true
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [true, true, false, true, true, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true, true, true, true, true]);
                 });
 
                 it('"false == false" evaluates to true', () => {
                     const input = `
                         .Value1 = false
                         .Value2 = false
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, false, false, false, false, true]);
+                    assertEvaluatedVariablesValueEqual(input, [false, false, false, false, true]);
                 });
 
                 it('"true == false" evaluates to false', () => {
                     const input = `
                         .Value1 = true
                         .Value2 = false
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [true, false, false, true, false]);
+                    assertEvaluatedVariablesValueEqual(input, [true, false, true, false]);
                 });
 
                 it('"false == true" evaluates to false', () => {
                     const input = `
                         .Value1 = false
                         .Value2 = true
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, true, false, false, true]);
+                    assertEvaluatedVariablesValueEqual(input, [false, true, false, true]);
                 });
 
                 it('"true != true" evaluates to false', () => {
                     const input = `
                         .Value1 = true
                         .Value2 = true
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [true, true, false, true, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true, true, true, true]);
                 });
 
                 it('"false != false" evaluates to false', () => {
                     const input = `
                         .Value1 = false
                         .Value2 = false
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, false, false, false, false]);
+                    assertEvaluatedVariablesValueEqual(input, [false, false, false, false]);
                 });
 
                 it('"true != false" evaluates to true', () => {
                     const input = `
                         .Value1 = true
                         .Value2 = false
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [true, false, false, true, false, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true, false, true, false, true]);
                 });
 
                 it('"false != true" evaluates to true', () => {
                     const input = `
                         .Value1 = false
                         .Value2 = true
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, true, false, false, true, true]);
+                    assertEvaluatedVariablesValueEqual(input, [false, true, false, true, true]);
                 });
 
                 const illegalComparisonOperators = [
@@ -3002,642 +2990,592 @@ describe('evaluator', () => {
             describe('integer', () => {
                 it('"{1-literal} == {1-literal}" evaluates to true', () => {
                     const input = `
-                        .Result = false
                         If( 1 == 1 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true]);
                 });
 
                 it('"{1-literal} == {0-literal}" evaluates to false', () => {
                     const input = `
-                        .Result = false
                         If( 1 == 0 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false]);
+                    assertEvaluatedVariablesValueEqual(input, []);
                 });
 
                 it('"1 == {1-literal}" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
-                        .Result = false
                         If( .Value1 == 1 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, false, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, true]);
                 });
 
                 it('"{1-literal} == 1" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
-                        .Result = false
                         If( 1 == .Value1 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, false, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, true]);
                 });
 
                 it('"1 == 1" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 1, false, 1, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, 1, 1, true]);
                 });
 
                 it('"1 == 0" evaluates to false', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 0
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 0, false, 1, 0]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 0, 1, 0]);
                 });
 
                 it('"1 != 1" evaluates to false', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 1, false, 1, 1]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, 1, 1]);
                 });
 
                 it('"1 != 0" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 0
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 0, false, 1, 0, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 0, 1, 0, true]);
                 });
 
                 it('"0 < 1" evaluates to true', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, false, 0, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, true]);
                 });
 
                 it('"1 < 0" evaluates to false', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 0
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 0, false, 1, 0]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 0, 1, 0]);
                 });
 
                 it('"1 < 1" evaluates to false', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 1, false, 1, 1]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, 1, 1]);
                 });
 
                 it('"0 <= 1" evaluates to true', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, false, 0, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, true]);
                 });
 
                 it('"1 <= 0" evaluates to false', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 0
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 0, false, 1, 0]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 0, 1, 0]);
                 });
 
                 it('"1 <= 1" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 1, false, 1, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, 1, 1, true]);
                 });
 
                 it('"0 > 1" evaluates to false', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, false, 0, 1]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1]);
                 });
 
                 it('"1 > 0" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 0
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 0, false, 1, 0, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 0, 1, 0, true]);
                 });
 
                 it('"1 > 1" evaluates to false', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 1, false, 1, 1]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, 1, 1]);
                 });
 
                 it('"0 >= 1" evaluates to false', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, false, 0, 1]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1]);
                 });
 
                 it('"1 >= 0" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 0
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 0, false, 1, 0, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 0, 1, 0, true]);
                 });
 
                 it('"1 >= 1" evaluates to true', () => {
                     const input = `
                         .Value1 = 1
                         .Value2 = 1
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [1, 1, false, 1, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [1, 1, 1, 1, true]);
                 });
             });
 
             describe('string', () => {
                 it('"{cat-literal} == {cat-literal}" evaluates to true', () => {
                     const input = `
-                        .Result = false
                         If( 'cat' == 'cat' )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false, true]);
+                    assertEvaluatedVariablesValueEqual(input, [true]);
                 });
 
                 it('"{cat-literal} == {dog-literal}" evaluates to false', () => {
                     const input = `
-                        .Result = false
                         If( 'cat' == 'dog' )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [false]);
+                    assertEvaluatedVariablesValueEqual(input, []);
                 });
 
                 it('"cat == {cat-literal}" evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
-                        .Result = false
                         If( .Value1 == 'cat' )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', false, 'cat', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'cat', true]);
                 });
 
                 it('"{cat-literal} = cat" evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
-                        .Result = false
                         If( 'cat' == .Value1 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', false, 'cat', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'cat', true]);
                 });
 
                 it('"cat == cat" evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'cat'
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'cat', false, 'cat', 'cat', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'cat', 'cat', 'cat', true]);
                 });
 
                 it('"cat == Cat" (different case) evaluates to false', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'Cat'
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'Cat', false, 'cat', 'Cat']);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'Cat', 'cat', 'Cat']);
                 });
 
                 it('"cat == dog" evaluates to false', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 == .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', false, 'cat', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', 'cat', 'dog']);
                 });
 
                 it('"cat != cat" evaluates to false', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'cat'
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'cat', false, 'cat', 'cat']);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'cat', 'cat', 'cat']);
                 });
 
                 it('"cat != Cat" (different case) evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'Cat'
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'Cat', false, 'cat', 'Cat', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'Cat', 'cat', 'Cat', true]);
                 });
 
                 it('"cat != dog" evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 != .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', false, 'cat', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', 'cat', 'dog', true]);
                 });
 
                 it('"cat < dog" evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', false, 'cat', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', 'cat', 'dog', true]);
                 });
 
                 it('"dog < cat" evaluates to false', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'cat'
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', false, 'dog', 'cat']);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', 'dog', 'cat']);
                 });
 
                 it('"dog < dog" evaluates to false', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', false, 'dog', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', 'dog', 'dog']);
                 });
 
                 it('"Dog < dog" (different case) evaluates to true', () => {
                     const input = `
                         .Value1 = 'Dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', false, 'Dog', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', 'Dog', 'dog', true]);
                 });
 
                 it('"dog < Dog" (different case) evaluates to false', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'Dog'
-                        .Result = false
                         If( .Value1 < .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', false, 'dog', 'Dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', 'dog', 'Dog']);
                 });
 
                 it('"cat <= dog" evaluates to true', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', false, 'cat', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', 'cat', 'dog', true]);
                 });
 
                 it('"dog <= cat" evaluates to false', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'cat'
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', false, 'dog', 'cat']);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', 'dog', 'cat']);
                 });
 
                 it('"dog <= dog" evaluates to true', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', false, 'dog', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', 'dog', 'dog', true]);
                 });
 
                 it('"Dog <= dog" (different case) evaluates to true', () => {
                     const input = `
                         .Value1 = 'Dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', false, 'Dog', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', 'Dog', 'dog', true]);
                 });
 
                 it('"dog <= Dog" (different case) evaluates to false', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'Dog'
-                        .Result = false
                         If( .Value1 <= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', false, 'dog', 'Dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', 'dog', 'Dog']);
                 });
 
                 it('"cat > dog" evaluates to false', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', false, 'cat', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', 'cat', 'dog']);
                 });
 
                 it('"dog > cat" evaluates to true', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'cat'
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', false, 'dog', 'cat', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', 'dog', 'cat', true]);
                 });
 
                 it('"dog > dog" evaluates to false', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', false, 'dog', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', 'dog', 'dog']);
                 });
 
                 it('"Dog > dog" (different case) evaluates to false', () => {
                     const input = `
                         .Value1 = 'Dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', false, 'Dog', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', 'Dog', 'dog']);
                 });
 
                 it('"dog > Dog" (different case) evaluates to true', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'Dog'
-                        .Result = false
                         If( .Value1 > .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', false, 'dog', 'Dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', 'dog', 'Dog', true]);
                 });
 
                 it('"cat >= dog" evaluates to false', () => {
                     const input = `
                         .Value1 = 'cat'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', false, 'cat', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['cat', 'dog', 'cat', 'dog']);
                 });
 
                 it('"dog >= cat" evaluates to true', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'cat'
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', false, 'dog', 'cat', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'cat', 'dog', 'cat', true]);
                 });
 
                 it('"dog >= dog" evaluates to true', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', false, 'dog', 'dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'dog', 'dog', 'dog', true]);
                 });
 
                 it('"Dog >= dog" (different case) evaluates to false', () => {
                     const input = `
                         .Value1 = 'Dog'
                         .Value2 = 'dog'
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', false, 'Dog', 'dog']);
+                    assertEvaluatedVariablesValueEqual(input, ['Dog', 'dog', 'Dog', 'dog']);
                 });
 
                 it('"dog >= Dog" (different case) evaluates to true', () => {
                     const input = `
                         .Value1 = 'dog'
                         .Value2 = 'Dog'
-                        .Result = false
                         If( .Value1 >= .Value2 )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', false, 'dog', 'Dog', true]);
+                    assertEvaluatedVariablesValueEqual(input, ['dog', 'Dog', 'dog', 'Dog', true]);
                 });
             });
 
@@ -4090,39 +4028,36 @@ describe('evaluator', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( (.Value1 < .Value2) && (.Value1 > .Value2) )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, false]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, 0, 1]);
                 });
 
                 it('"(0 < 1) || (0 > 1)" evaluates to true', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( (.Value1 < .Value2) || (.Value1 > .Value2) )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, 0, 1, true]);
                 });
 
                 it('"(0 > 1) || (0 < 1)" evaluates to true', () => {
                     const input = `
                         .Value1 = 0
                         .Value2 = 1
-                        .Result = false
                         If( (.Value1 > .Value2) || (.Value1 < .Value2) )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
-                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, true]);
+                    assertEvaluatedVariablesValueEqual(input, [0, 1, 0, 1, 0, 1, true]);
                 });
             });
 
@@ -4131,13 +4066,14 @@ describe('evaluator', () => {
                     const input = `
                         .Needle = 'b'
                         .Haystack = {'a', 'b', 'c'}
-                        .Result = false
                         If( (.Needle in .Haystack) && true )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
                     assertEvaluatedVariablesValueEqual(input, [
+                        'b',
+                        ['a', 'b', 'c'],
                         'b',
                         ['a', 'b', 'c'],
                         true
@@ -4148,16 +4084,16 @@ describe('evaluator', () => {
                     const input = `
                         .Needle = 'b'
                         .Haystack = {'a', 'b', 'c'}
-                        .Result = false
                         If( (.Needle in .Haystack) && false )
                         {
-                            ^Result = true
+                            .Result = true
                         }
                     `;
                     assertEvaluatedVariablesValueEqual(input, [
                         'b',
                         ['a', 'b', 'c'],
-                        false
+                        'b',
+                        ['a', 'b', 'c'],
                     ]);
                 });
             });
@@ -4353,7 +4289,7 @@ Expecting to see one of the following:
                     }
                     Func()
                 `;
-                assertEvaluatedVariablesValueEqual(input, [1]);
+                assertEvaluatedVariablesValueEqual(input, [1, 1]);
             });
 
             it('Body on the same line', () => {
@@ -4405,7 +4341,7 @@ Expecting to see the following:
                     }
                     Func(.MyVar)
                 `;
-                assertEvaluatedVariablesValueEqual(input, [1, 1]);
+                assertEvaluatedVariablesValueEqual(input, [1, 1, 1]);
             });
 
             it('Body on the same line', () => {
@@ -4522,7 +4458,6 @@ Expecting to see the following:
                 const input = `
                     function FuncA() {
                         .MyVar = 1
-                        Print( .MyVar )
                     }
 
                     function FuncB() {
@@ -4556,14 +4491,13 @@ Expecting to see the following:
                     'file:///fbuild.bff',
                     `
                         #include 'helper.bff'
-                        .Copy = .FromHelper
+                        Print( .FromHelper )
                     `
                 ],
                 [
                     'file:///helper.bff',
                     `
                         .FromHelper = 1
-                        .Copy = .FromHelper
                     `
                 ]
             ]), true /*enableDiagnostics*/);
@@ -4571,11 +4505,11 @@ Expecting to see the following:
             assert.deepStrictEqual(result.evaluatedVariables, [
                 {
                     value: 1,
-                    range: createFileRange('file:///helper.bff', 2, 32, 2, 43),
+                    range: createFileRange('file:///helper.bff', 1, 24, 1, 35),
                 },
                 {
                     value: 1,
-                    range: createFileRange('file:///fbuild.bff', 2, 32, 2, 43),
+                    range: createFileRange('file:///fbuild.bff', 2, 31, 2, 42),
                 }
             ]);
 
@@ -4586,16 +4520,8 @@ Expecting to see the following:
                 kind: DefinitionKind.Variable,
             };
 
-            const definitionCopy: VariableDefinition = {
-                id: 2,
-                range: createFileRange('file:///helper.bff', 2, 24, 2, 29),
-                name: 'Copy',
-                kind: DefinitionKind.Variable,
-            };
-
             assert.deepStrictEqual(result.variableDefinitions, [
                 definitionFromHelper,  // FromHelper
-                definitionCopy,  // Copy
             ]);
 
             assert.deepStrictEqual(result.variableReferences, [
@@ -4604,25 +4530,10 @@ Expecting to see the following:
                     definition: definitionFromHelper,
                     range: createFileRange('file:///helper.bff', 1, 24, 1, 35),
                 },
-                // helper.bff ".Copy = .FromHelper" RHS
+                // fbuild.bff "Print( .FromHelper )"
                 {
                     definition: definitionFromHelper,
-                    range: createFileRange('file:///helper.bff', 2, 32, 2, 43),
-                },
-                // helper.bff ".Copy = .FromHelper" LHS
-                {
-                    definition: definitionCopy,
-                    range: createFileRange('file:///helper.bff', 2, 24, 2, 29),
-                },
-                // fbuild.bff ".Copy = .FromHelper" RHS
-                {
-                    definition: definitionFromHelper,
-                    range: createFileRange('file:///fbuild.bff', 2, 32, 2, 43),
-                },
-                // fbuild.bff ".Copy = .FromHelper" LHS
-                {
-                    definition: definitionCopy,
-                    range: createFileRange('file:///fbuild.bff', 2, 24, 2, 29),
+                    range: createFileRange('file:///fbuild.bff', 2, 31, 2, 42),
                 },
             ]);
         });
@@ -4646,6 +4557,10 @@ Expecting to see the following:
             ]), true /*enableDiagnostics*/);
 
             assert.deepStrictEqual(result.evaluatedVariables, [
+                {
+                    value: 'Bobo',
+                    range: createFileRange('file:///some/path/fbuild.bff', 1, 24, 1, 29),
+                },
                 {
                     value: 'Bobo',
                     range: createFileRange('file:///some/path/greetings.bff', 1, 38, 1, 44),
@@ -4693,7 +4608,15 @@ Expecting to see the following:
             assert.deepStrictEqual(result.evaluatedVariables, [
                 {
                     value: 'dog',
+                    range: createFileRange('file:///some/path/animals/dog.bff', 1, 24, 1, 29),
+                },
+                {
+                    value: 'dog',
                     range: createFileRange('file:///some/path/greetings.bff', 1, 42, 1, 48),
+                },
+                {
+                    value: 'Hello dog',
+                    range: createFileRange('file:///some/path/greetings.bff', 1, 24, 1, 32),
                 },
                 {
                     value: 'Hello dog',
@@ -4701,7 +4624,15 @@ Expecting to see the following:
                 },
                 {
                     value: 'cat',
+                    range: createFileRange('file:///some/path/animals/cat.bff', 1, 24, 1, 29),
+                },
+                {
+                    value: 'cat',
                     range: createFileRange('file:///some/path/greetings.bff', 1, 42, 1, 48),
+                },
+                {
+                    value: 'Hello cat',
+                    range: createFileRange('file:///some/path/greetings.bff', 1, 24, 1, 32),
                 },
                 {
                     value: 'Hello cat',
@@ -4732,6 +4663,10 @@ Expecting to see the following:
             ]), true /*enableDiagnostics*/);
 
             assert.deepStrictEqual(result.evaluatedVariables, [
+                {
+                    value: 'Bobo',
+                    range: createFileRange('file:///some/path/fbuild.bff', 1, 24, 1, 29),
+                },
                 {
                     value: 'Bobo',
                     range: createFileRange('file:///some/path/greetings.bff', 2, 38, 2, 44),

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -4687,7 +4687,7 @@ Expecting to see the following:
                     'file:///some/path/greetings.bff',
                     `
                         #once
-                        .Message = 'Hello $Name$'
+                        Print( 'Hello $Name$' )
                     `
                 ],
                 [
@@ -4709,7 +4709,15 @@ Expecting to see the following:
             assert.deepStrictEqual(result.evaluatedVariables, [
                 {
                     value: 'dog',
-                    range: createFileRange('file:///some/path/greetings.bff', 2, 42, 2, 48),
+                    range: createFileRange('file:///some/path/animals/dog.bff', 1, 24, 1, 29),
+                },
+                {
+                    value: 'dog',
+                    range: createFileRange('file:///some/path/greetings.bff', 2, 38, 2, 44),
+                },
+                {
+                    value: 'cat',
+                    range: createFileRange('file:///some/path/animals/cat.bff', 1, 24, 1, 29),
                 },
             ]);
         });
@@ -4721,156 +4729,128 @@ Expecting to see the following:
 
         it('A platform-specific symbol is defined', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('"!DEFINE" on a defined symbol evaluates to false', () => {
             const input = `
-                .Value = false
                 #if !${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('"!DEFINE" on an undefined symbol evaluates to true', () => {
             const input = `
-                .Value = false
                 #if ! NON_EXISTENT_SYMBOL
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('true && true evaulates to true', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} && ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('true && false evaulates to false', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} && !${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('false && true evaulates to false', () => {
             const input = `
-                .Value = false
                 #if !${builtInDefine} && ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('false && false evaulates to false', () => {
             const input = `
-                .Value = false
                 #if !${builtInDefine} && !${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('true || true evaulates to true', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} || ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('true || false evaulates to true', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} || !${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('false || true evaulates to true', () => {
             const input = `
-                .Value = false
                 #if !${builtInDefine} || ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('false || false evaulates to false', () => {
             const input = `
-                .Value = false
                 #if !${builtInDefine} || !${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('false && false || true evaulates to true (&& takes precedence over ||) variation 1', () => {
             const input = `
-                .Value = false
                 #if !${builtInDefine} && !${builtInDefine} || ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('true || false && false evaulates to true (&& takes precedence over ||) variation 1', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} || !${builtInDefine} && !${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('#else body is evaluated when the #if condition is false', () => {
             const input = `
-                .Value = ''
                 #if !${builtInDefine}
                     .Value = 'if'
                 #else
                     .Value = 'else'
                 #endif
-                Print( .Value )
             `;
 
             assertEvaluatedVariablesValueEqual(input, ['else']);
@@ -4884,7 +4864,6 @@ Expecting to see the following:
                     + 'B'
                 #endif
                     + 'C'
-                Print( .Value )
             `;
 
             assertEvaluatedVariablesValueEqual(input, ['ABC']);
@@ -4900,7 +4879,6 @@ Expecting to see the following:
                     + 'b'
                 #endif
                     + 'C'
-                Print( .Value )
             `;
 
             assertEvaluatedVariablesValueEqual(input, ['AbC']);
@@ -4917,7 +4895,6 @@ Expecting to see the following:
                     #endif
                     'C'
                 }
-                Print( .Value )
             `;
 
             assertEvaluatedVariablesValueEqual(input, [['A', 'B', 'C']]);
@@ -4934,13 +4911,15 @@ Expecting to see the following:
                     #endif
                     .C = 3
                 ]
-                Print( .Value )
             `;
 
             const myVarADefinition: VariableDefinition = { id: 1, range: createRange(2, 20, 2, 22), name: 'A', kind: DefinitionKind.Variable };
             const myVarBDefinition: VariableDefinition = { id: 2, range: createRange(4, 24, 4, 26), name: 'B', kind: DefinitionKind.Variable };
             const myVarCDefinition: VariableDefinition = { id: 3, range: createRange(8, 20, 8, 22), name: 'C', kind: DefinitionKind.Variable };
             assertEvaluatedVariablesValueEqual(input, [
+                1,
+                2,
+                3,
                 Struct.from(Object.entries({
                     A: new StructMember(1, myVarADefinition),
                     B: new StructMember(2, myVarBDefinition),
@@ -4955,44 +4934,36 @@ Expecting to see the following:
 
         it('"#if exists(...)" always evaluates to false', () => {
             const input = `
-                .Value = false
                 #if exists(MY_ENV_VAR)
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('"#if !exists(...)" always evaluates to true', () => {
             const input = `
-                .Value = false
                 #if !exists( MY_ENV_VAR )
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('"exists" can be combined with ||', () => {
             const input = `
-                .Value = false
                 #if exists(MY_ENV_VAR) || ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('"exists" can be combined with &&', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} && !exists(MY_ENV_VAR)
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
@@ -5006,11 +4977,9 @@ Expecting to see the following:
                 [
                     'file:///base/fbuild.bff',
                     `
-                        .Value = false
                         #if file_exists('sibling.txt')
                             .Value = true
                         #endif
-                        Print( .Value )
                     `
                 ],
                 [
@@ -5027,11 +4996,9 @@ Expecting to see the following:
                 [
                     'file:///base/fbuild.bff',
                     `
-                        .Value = false
                         #if file_exists('../uncle.txt')
                             .Value = true
                         #endif
-                        Print( .Value )
                     `
                 ],
                 [
@@ -5048,11 +5015,9 @@ Expecting to see the following:
                 [
                     'file:///base/fbuild.bff',
                     `
-                        .Value = false
                         #if file_exists('/base/sibling.txt')
                             .Value = true
                         #endif
-                        Print( .Value )
                     `
                 ],
                 [
@@ -5066,13 +5031,11 @@ Expecting to see the following:
 
         it('"#if file_exists(...)" evaluates to false for a path that does not exist', () => {
             const input = `
-                .Value = false
                 #if file_exists('path/that/does/not/exist.txt')
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('"#if !file_exists(...)" evaluates to false for a path that exists', () => {
@@ -5080,11 +5043,9 @@ Expecting to see the following:
                 [
                     'file:///base/fbuild.bff',
                     `
-                        .Value = false
                         #if !file_exists('sibling.txt')
                             .Value = true
                         #endif
-                        Print( .Value )
                     `
                 ],
                 [
@@ -5093,40 +5054,34 @@ Expecting to see the following:
                 ],
             ]), true /*enableDiagnostics*/);
             const actualValues = result.evaluatedVariables.map(evaluatedVariable => evaluatedVariable.value);
-            assert.deepStrictEqual(actualValues, [false]);
+            assert.deepStrictEqual(actualValues, []);
         });
 
         it('"#if !file_exists(...)" evaluates to true for a path that does not exist', () => {
             const input = `
-                .Value = false
                 #if !file_exists('path/that/does/not/exist.txt')
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('"file_exists" can be combined with ||', () => {
             const input = `
-                .Value = false
                 #if file_exists('path/that/does/not/exist.txt') || ${builtInDefine}
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
 
         it('"file_exists" can be combined with &&', () => {
             const input = `
-                .Value = false
                 #if ${builtInDefine} && file_exists('path/that/does/not/exist.txt')
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
     });
 
@@ -5134,11 +5089,9 @@ Expecting to see the following:
         it('basic', () => {
             const input = `
                 #define MY_DEFINE
-                .Value = false
                 #if MY_DEFINE
                     .Value = true
                 #endif
-                Print( .Value )
             `;
             assertEvaluatedVariablesValueEqual(input, [true]);
         });
@@ -5158,13 +5111,11 @@ Expecting to see the following:
             const input = `
                 #define MY_DEFINE
                 #undef MY_DEFINE
-                .Value = false
                 #if MY_DEFINE
                     .Value = true
                 #endif
-                Print( .Value )
             `;
-            assertEvaluatedVariablesValueEqual(input, [false]);
+            assertEvaluatedVariablesValueEqual(input, []);
         });
 
         it('undefining an undefined symbol is an error', () => {


### PR DESCRIPTION
You can now hover over the left-hand side of a variable assignment or modification to see the variable's new value.