### PR TITLE
Support "go to definition" and "find references" for `#define`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.5.0
+
+## New Features
+
+* Support "go to definition" and "find references" for `#define`s:
+    * [`#define` / `#undef` FASTBuild docs](https://www.fastbuild.org/docs/syntaxguide.html#define)
+    * [`#if` / `#else` / `#endif` FASTBuild docs](https://www.fastbuild.org/docs/syntaxguide.html#if)
+
 # v0.4.0
 
 ## New Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,14 @@
 
 ## About the code
 
-* Parses using the [Nearley](https://nearley.js.org/) parser generator, which lexes using [moo](https://github.com/no-context/moo).
-    * [Nearley Parser Playground](https://omrelli.ug/nearley-playground/)
-    * Example: [Moo.js Tokenizer with Nearley.js](https://www.youtube.com/watch?v=GP91_duEmk8)
+* [parser.ts](server/src/parser.ts) parses FASTBuild files.
+    * It uses the [Nearley](https://nearley.js.org/) parser generator, which lexes using [moo](https://github.com/no-context/moo).
+        * [Nearley Parser Playground](https://omrelli.ug/nearley-playground/)
+        * Example: [Moo.js Tokenizer with Nearley.js](https://www.youtube.com/watch?v=GP91_duEmk8)
+    * It uses the FASTBuild grammaer defined in [fbuild-grammar.ne](server/src/fbuild-grammar.ne).
+* [evaluator.ts](server/src/evaluator.ts) evaluates the parsed input.
+* The lanaguage server ([server.ts](server/src/server.ts)) uses [feature providers](server/src//features/) to implement the server's capabilities.
 * VS Code language server extension resources:
     * [VS Code Language Server Extension Guide](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide)
     * [How to create a language server and VS Code extension](https://github.com/donaldpipowitch/how-to-create-a-language-server-and-vscode-extension)
     * [Language Server Protocol: A Language Server For DOT With Visual Studio Code](https://tomassetti.me/language-server-dot-visual-studio/)
-* Other resources:
-    * [RegEx101](https://regex101.com/): regex playgound

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ Contains a language server and Visual Studio Code client for the [FASTBuild](htt
 ## Functionality
 
 This provides the following functionality:
-* Go to definition of a variable.
-* Find references to a variable.
-* Hover over an evaluated variable to show a tooltip with its evaulated value (e.g. the evaluated `Location` variable in `.Message = 'Hello $Location$'` or `.Message = .Location`).
-* Show diagnostics for errors.
+* "Go to definition" and "Find references" for:
+    * Variables
+    * `#import`s
+    * `#define`s
+* Hover over a variable to show a tooltip with its evaulated value (e.g. the evaluated `Location` variable in `.Message = 'Hello $Location$'` or `.Message = .Location`).
+* See errors on the fly as you write the code, before running FASTBuild.
 * Go to symbol in editor or workspace.
 
 It does not yet provide syntax highlighting. For that in the meantime, I recommend the FASTBuild (`roscop.fastbuild`) extension ([extension website](https://marketplace.visualstudio.com/items?itemName=RoscoP.fastbuild)).
 
 ## Limitations
 
-* Only evaluates user functions if they are called at least once. This means that you cannot jump to the definition of a variable defined inside a user function if that user function is never called, for example.
+* Only evaluates code if it is called at least once. This means, for example, that you cannot jump to the definition of a variable defined inside a user function if that user function is never called.
 
 ## Compatibility
 
@@ -35,4 +37,4 @@ Install the extension from the [Visual Studio Marketplace](https://marketplace.v
 
 ## Contributing
 
-Contributions are always welcome. Please see our [contributing guide](CONTRIBUTING.md) for more details.
+Contributions welcome! See the [contribution guide](CONTRIBUTING.md) for details.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/fbuild-grammar.ne
+++ b/server/src/fbuild-grammar.ne
@@ -902,7 +902,11 @@ directiveIfConditionOrExpression ->
         return [[value], context];
     } %}
     # Multiple items ||'d together
-  | directiveIfConditionAndExpression optionalWhitespace %operatorOr optionalWhitespace directiveIfConditionOrExpression  {% ([[lhsValue, lhsContext], space1, or, space2, [rhsValues, rhsContext]]) => {
+  | directiveIfConditionAndExpression             %operatorOr optionalWhitespace directiveIfConditionOrExpression  {% ([[lhsValue, lhsContext],         or, space2, [rhsValues, rhsContext]]) => {
+        callOnNextToken(lhsContext, or);
+        return [[lhsValue, ...rhsValues], rhsContext];
+    } %}
+  | directiveIfConditionAndExpression %whitespace %operatorOr optionalWhitespace directiveIfConditionOrExpression  {% ([[lhsValue, lhsContext], space1, or, space2, [rhsValues, rhsContext]]) => {
         callOnNextToken(lhsContext, space1);
         return [[lhsValue, ...rhsValues], rhsContext];
     } %}
@@ -914,7 +918,11 @@ directiveIfConditionAndExpression ->
         return [[value], context];
     } %}
     # Multiple items &&'d together
-  | directiveIfConditionTermOrNot optionalWhitespace %operatorAnd optionalWhitespace directiveIfConditionAndExpression  {% ([[lhsValue, lhsContext], space1, and, space2, [rhsValues, rhsContext]]) => {
+  | directiveIfConditionTermOrNot             %operatorAnd optionalWhitespace directiveIfConditionAndExpression  {% ([[lhsValue, lhsContext],         and, space2, [rhsValues, rhsContext]]) => {
+        callOnNextToken(lhsContext, and);
+        return [[lhsValue, ...rhsValues], rhsContext];
+    } %}
+  | directiveIfConditionTermOrNot %whitespace %operatorAnd optionalWhitespace directiveIfConditionAndExpression  {% ([[lhsValue, lhsContext], space1, and, space2, [rhsValues, rhsContext]]) => {
         callOnNextToken(lhsContext, space1);
         return [[lhsValue, ...rhsValues], rhsContext];
     } %}

--- a/server/src/fbuild-grammar.ne
+++ b/server/src/fbuild-grammar.ne
@@ -912,7 +912,11 @@ directiveIfConditionTerm ->
   | %exists     optionalWhitespace %parametersStart optionalWhitespace variableName  optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, [envVar, context], space3, closeBrace]) => { return { type: 'envVarExists'         }; } %}
   | %fileExists optionalWhitespace %parametersStart optionalWhitespace stringLiteral optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, filePath,          space3, closeBrace]) => { return { type: 'fileExists', filePath }; } %}
 
-directiveDefine   -> %directiveDefine   %whitespace variableName  {% ([define,   space, [symbol, context]]) => [{ type: 'define',   symbol }, context] %}
+directiveDefine   -> %directiveDefine   %whitespace variableName  {% ([define,   space, [symbol, varNameContext]]) => {
+    const [range, statementContext] = createRangeStart(define);
+    const context = createCombinedContext([statementContext, varNameContext]);
+    return [{ type: 'define', symbol, range }, context]
+} %}
 
 directiveUndefine -> %directiveUndefine %whitespace variableName  {% ([undefine, space, [symbol, context]]) => [{ type: 'undefine', symbol }, context] %}
 

--- a/server/src/fbuild-grammar.ne
+++ b/server/src/fbuild-grammar.ne
@@ -881,36 +881,69 @@ directiveInclude -> %directiveInclude optionalWhitespaceOrNewline stringLiteral 
 directiveOnce -> %directiveOnce  {% () => { return { type: 'once' }; } %}
 
 directiveIf ->
-    %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline lines                                                             %directiveEndIf  {% ([directiveIf, space1, condition, space2, ifStatements,                                        directiveEndIf]) => { return { type: 'directiveIf', condition, ifStatements, elseStatements: [], rangeStart: createLocation(directiveIf) }; } %}
-  | %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline lines %directiveElse %optionalWhitespaceAndMandatoryNewline lines %directiveEndIf  {% ([directiveIf, space1, condition, space2, ifStatements, directiveElse, space3, elseStatements, directiveEndIf]) => { return { type: 'directiveIf', condition, ifStatements, elseStatements    , rangeStart: createLocation(directiveIf) }; } %}
+    %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline lines                                                             %directiveEndIf  {% ([directiveIf, space1, [condition, context], space2, ifStatements,                                        directiveEndIf]) => {
+        callOnNextToken(context, space2);
+        return { type: 'directiveIf', condition, ifStatements, elseStatements: [], rangeStart: createLocation(directiveIf)};
+    } %}
+  | %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline lines %directiveElse %optionalWhitespaceAndMandatoryNewline lines %directiveEndIf  {% ([directiveIf, space1, [condition, context], space2, ifStatements, directiveElse, space3, elseStatements, directiveEndIf]) => {
+        callOnNextToken(context, space2);
+        return { type: 'directiveIf', condition, ifStatements, elseStatements    , rangeStart: createLocation(directiveIf)};
+    } %}
 
 # Like `directIf` but the contents can only be `arrayContents`.
 directiveIfContainingArrayContents ->
-    %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline arrayContents                                                                     %directiveEndIf  {% ([directiveIf, space1, condition, space2, [ifContents, ifContentsContext],                                                             directiveEndIf]) => { callOnNextToken(ifContentsContext, directiveEndIf);                                                        return { type: 'directiveIf', condition, ifStatements: ifContents, elseStatements: [],           rangeStart: createLocation(directiveIf) }; } %}
-  | %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline arrayContents %directiveElse %optionalWhitespaceAndMandatoryNewline arrayContents %directiveEndIf  {% ([directiveIf, space1, condition, space2, [ifContents, ifContentsContext], directiveElse, space3, [elseContents, elseContentsContext], directiveEndIf]) => { callOnNextToken(ifContentsContext, directiveElse );  callOnNextToken(elseContentsContext, directiveEndIf); return { type: 'directiveIf', condition, ifStatements: ifContents, elseStatements: elseContents, rangeStart: createLocation(directiveIf) }; } %}
+    %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline arrayContents                                                                     %directiveEndIf  {% ([directiveIf, space1, [condition, conditionContext], space2, [ifContents, ifContentsContext],                                                             directiveEndIf]) => { callOnNextToken(conditionContext, space2); callOnNextToken(ifContentsContext, directiveEndIf);                                                        return { type: 'directiveIf', condition, ifStatements: ifContents, elseStatements: [],           rangeStart: createLocation(directiveIf) }; } %}
+  | %directiveIf %whitespace directiveIfConditionOrExpression %optionalWhitespaceAndMandatoryNewline arrayContents %directiveElse %optionalWhitespaceAndMandatoryNewline arrayContents %directiveEndIf  {% ([directiveIf, space1, [condition, conditionContext], space2, [ifContents, ifContentsContext], directiveElse, space3, [elseContents, elseContentsContext], directiveEndIf]) => { callOnNextToken(conditionContext, space2); callOnNextToken(ifContentsContext, directiveElse );  callOnNextToken(elseContentsContext, directiveEndIf); return { type: 'directiveIf', condition, ifStatements: ifContents, elseStatements: elseContents, rangeStart: createLocation(directiveIf) }; } %}
 
+# Returns [or-expression, context]
 directiveIfConditionOrExpression ->
     # Single item
-    directiveIfConditionAndExpression  {% ([value]) => [value] %}
+    directiveIfConditionAndExpression  {% ([[value, context]]) => {
+        return [[value], context];
+    } %}
     # Multiple items ||'d together
-  | directiveIfConditionAndExpression optionalWhitespace %operatorOr optionalWhitespace directiveIfConditionOrExpression  {% ([lhsValue, space1, or, space2, rhsValues]) => [lhsValue, ...rhsValues] %}
+  | directiveIfConditionAndExpression optionalWhitespace %operatorOr optionalWhitespace directiveIfConditionOrExpression  {% ([[lhsValue, lhsContext], space1, or, space2, [rhsValues, rhsContext]]) => {
+        callOnNextToken(lhsContext, space1);
+        return [[lhsValue, ...rhsValues], rhsContext];
+    } %}
 
+# Returns [and-expression, context]
 directiveIfConditionAndExpression ->
     # Single item
-    directiveIfConditionTermOrNot  {% ([value]) => [value] %}
+    directiveIfConditionTermOrNot  {% ([[value, context]]) => {
+        return [[value], context];
+    } %}
     # Multiple items &&'d together
-  | directiveIfConditionTermOrNot optionalWhitespace %operatorAnd optionalWhitespace directiveIfConditionAndExpression  {% ([lhsValue, space1, and, space2, rhsValues]) => [lhsValue, ...rhsValues] %}
+  | directiveIfConditionTermOrNot optionalWhitespace %operatorAnd optionalWhitespace directiveIfConditionAndExpression  {% ([[lhsValue, lhsContext], space1, and, space2, [rhsValues, rhsContext]]) => {
+        callOnNextToken(lhsContext, space1);
+        return [[lhsValue, ...rhsValues], rhsContext];
+    } %}
 
+# Returns [term-or-not, context]
 directiveIfConditionTermOrNot ->
     # SYMBOL
-                                    directiveIfConditionTerm  {% ([            term]) => { return { term, invert: false }; } %}
+                                    directiveIfConditionTerm  {% ([            [term, context]]) => {
+        return [{ term, invert: false }, context];
+    } %}
     # ! SYMBOL
-  | %operatorNot optionalWhitespace directiveIfConditionTerm  {% ([not, space, term]) => { return { term, invert: true  }; } %}
+  | %operatorNot optionalWhitespace directiveIfConditionTerm  {% ([not, space, [term, context]]) => {
+        return [{ term, invert: true },  context];
+    } %}
 
+# Returns [term, context]
 directiveIfConditionTerm ->
-    variableName  {% ([[symbol, context]]) => { return { type: 'isSymbolDefined', symbol: symbol.value }; } %}
-  | %exists     optionalWhitespace %parametersStart optionalWhitespace variableName  optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, [envVar, context], space3, closeBrace]) => { return { type: 'envVarExists'         }; } %}
-  | %fileExists optionalWhitespace %parametersStart optionalWhitespace stringLiteral optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, filePath,          space3, closeBrace]) => { return { type: 'fileExists', filePath }; } %}
+    %variableName  {% ([symbol]) => {
+        const [range, context] = createRangeStart(symbol);
+        return [{ type: 'isSymbolDefined', symbol: symbol.value, range }, context];
+    } %}
+  | %exists     optionalWhitespace %parametersStart optionalWhitespace variableName  optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, [envVar, context], space3, closeBrace]) => {
+        const range = 'TODO';
+        return [{ type: 'envVarExists', envVar, range }, context];
+    } %}
+  | %fileExists optionalWhitespace %parametersStart optionalWhitespace stringLiteral optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, filePath,          space3, closeBrace]) => {
+        const range = 'TODO';
+        return [{ type: 'fileExists', filePath, range }, new ParseContext()];
+    } %}
 
 directiveDefine   -> %directiveDefine   %whitespace variableName  {% ([define,   space, [symbol, varNameContext]]) => {
     const [range, statementContext] = createRangeStart(define);

--- a/server/src/test/1-parser.test.ts
+++ b/server/src/test/1-parser.test.ts
@@ -2958,8 +2958,9 @@ Expecting to see one of the following:
                                         invert: false,
                                         term: {
                                             type: 'isSymbolDefined',
-                                            symbol: '__WINDOWS__'
-                                        }
+                                            symbol: '__WINDOWS__',
+                                            range: createRange(3, 28, 3, 39),
+                                        },
                                     }
                                 ]
                             ],

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -5110,7 +5110,7 @@ Expecting to see the following:
                 // #define MY_DEFINE
                 {
                     definition: expectedDefinitionMyDefine,
-                    range: createRange(1, 16, 1, 33),
+                    range: expectedDefinitionMyDefine.range,
                 },
                 // #if MY_DEFINE
                 {
@@ -5120,7 +5120,7 @@ Expecting to see the following:
                 // .Result = true
                 {
                     definition: expectedDefinitionResult,
-                    range: createRange(3, 20, 3, 34),
+                    range: expectedDefinitionResult.range,
                 },
             ];
             assert.deepStrictEqual(result.variableReferences, expectedReferences);
@@ -5132,7 +5132,7 @@ Expecting to see the following:
                 #define MY_DEFINE
             `;
             const expectedErrorMessage = `Cannot #define already defined symbol "MY_DEFINE".`;
-            assertEvaluationError(input, expectedErrorMessage, createParseRange(2, 24, 2, 33));
+            assertEvaluationError(input, expectedErrorMessage, createParseRange(2, 16, 2, 33));
         });
     });
 
@@ -5147,10 +5147,9 @@ Expecting to see the following:
             `;
             assertEvaluatedVariablesValueEqual(input, []);
 
-
             const result = evaluateInput(input, true /*enableDiagnostics*/);
             const actualEvaluatedValues = result.evaluatedVariables.map(evaluatedVariable => evaluatedVariable.value);
-            assert.deepStrictEqual(actualEvaluatedValues, [true]);
+            assert.deepStrictEqual(actualEvaluatedValues, []);
 
             //
             // The `#if MY_DEFINE` does not reference `MY_DEFINE` because it's already undefined

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -5084,7 +5084,7 @@ Expecting to see the following:
             `;
 
             const result = evaluateInput(input, true /*enableDiagnostics*/);
-            const actualEvaluatedValues = result.evaluatedVariables.map(evaluatedVariable => evaluatedVariable.Result);
+            const actualEvaluatedValues = result.evaluatedVariables.map(evaluatedVariable => evaluatedVariable.value);
             assert.deepStrictEqual(actualEvaluatedValues, [true]);
 
             // #define MY_DEFINE
@@ -5097,7 +5097,7 @@ Expecting to see the following:
             // .Result = true
             const expectedDefinitionResult: VariableDefinition = {
                 id: 2,
-                range: createRange(3, 20, 3, 34),
+                range: createRange(3, 20, 3, 27),
                 name: 'Result'
             };
 


### PR DESCRIPTION
* [`#define` / `#undef` FASTBuild docs](https://www.fastbuild.org/docs/syntaxguide.html#define)
* [`#if` / `#else` / `#endif` FASTBuild docs](https://www.fastbuild.org/docs/syntaxguide.html#if)

Fixes #21 