### PR TITLE
`#if exists(...)` now correctly evaluates if the environment variable exists instead of always being false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.1
+
+## Bug Fixes
+
+* `#if exists(...)` now correctly evaluates if the environment variable exists instead of always being false (#23).
+
 # v0.5.0
 
 ## New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/fbuild-grammar.ne
+++ b/server/src/fbuild-grammar.ne
@@ -944,27 +944,28 @@ directiveIfConditionTerm ->
         const [range, context] = createRangeStart(symbol);
         return [{ type: 'isSymbolDefined', symbol: symbol.value, range }, context];
     } %}
-  | %exists     optionalWhitespace %parametersStart optionalWhitespace variableName  optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, [envVar, context], space3, closeBrace]) => {
-        const range = 'TODO';
-        return [{ type: 'envVarExists', envVar, range }, context];
+  | %exists     optionalWhitespace %parametersStart optionalWhitespace %variableName  optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, envVar,   space3, closeBrace]) => {
+        const range = createRangeEndInclusive(exists, closeBrace);
+        return [{ type: 'envVarExists', envVar: envVar.value, range }, new ParseContext()];
     } %}
-  | %fileExists optionalWhitespace %parametersStart optionalWhitespace stringLiteral optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, filePath,          space3, closeBrace]) => {
-        const range = 'TODO';
+  | %fileExists optionalWhitespace %parametersStart optionalWhitespace stringLiteral  optionalWhitespace %parametersEnd {% ([exists, space1, openBrace, space2, filePath, space3, closeBrace]) => {
+        const range = createRangeEndInclusive(exists, closeBrace);
         return [{ type: 'fileExists', filePath, range }, new ParseContext()];
     } %}
 
-directiveDefine   -> %directiveDefine   %whitespace variableName  {% ([define,   space, [symbol, varNameContext]]) => {
-    const [range, statementContext] = createRangeStart(define);
-    const context = createCombinedContext([statementContext, varNameContext]);
-    return [{ type: 'define', symbol, range }, context]
+directiveDefine   -> %directiveDefine   %whitespace %variableName  {% ([define, space, symbol]) => {
+    const [range, context] = createRangeStart(define);
+    return [{ type: 'define', symbol: symbol.value, range }, context]
 } %}
 
-directiveUndefine -> %directiveUndefine %whitespace variableName  {% ([undefine, space, [symbol, context]]) => [{ type: 'undefine', symbol }, context] %}
+directiveUndefine -> %directiveUndefine %whitespace %variableName  {% ([undefine, space, symbol]) => {
+    const [range, context] = createRangeStart(undefine);
+    return [{ type: 'undefine', symbol: symbol.value, range }, context];
+} %}
 
-directiveImport   -> %directiveImport   %whitespace variableName  {% ([directiveImport, space, [symbol, varNameContext]]) => {
-    const [range, statementContext] = createRangeStart(directiveImport);
-    const context = createCombinedContext([statementContext, varNameContext]);
-    return [{ type: 'importEnvVar', symbol, range }, context];
+directiveImport   -> %directiveImport   %whitespace %variableName  {% ([directiveImport, space, symbol]) => {
+    const [range, context] = createRangeStart(directiveImport);
+    return [{ type: 'importEnvVar', symbol: symbol.value, range }, context];
 } %}
 
 whitespaceOrNewline ->

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -4920,8 +4920,18 @@ Expecting to see the following:
 
     describe('#if exists', () => {
         const builtInDefine = getPlatformSpecificDefineSymbol();
+        const builtInEnvVar = getPlatformSpecificEnvironmentVariable();
 
-        it('"#if exists(UNSET_ENV_VAR)" always evaluates to false', () => {
+        it('"exists" evaluates to true if the environment variable exists', () => {
+            const input = `
+                #if exists(${builtInEnvVar})
+                    .Value = true
+                #endif
+            `;
+            assertEvaluatedVariablesValueEqual(input, [true]);
+        });
+
+        it('"exists" evaluates to false if the environment variable does not exist', () => {
             const input = `
                 #if exists(UNSET_ENV_VAR)
                     .Value = true
@@ -4930,7 +4940,16 @@ Expecting to see the following:
             assertEvaluatedVariablesValueEqual(input, []);
         });
 
-        it('"#if !exists(UNSET_ENV_VAR)" always evaluates to true', () => {
+        it('Negating an existent result evaluates to false', () => {
+            const input = `
+                #if !exists( ${builtInEnvVar} )
+                    .Value = true
+                #endif
+            `;
+            assertEvaluatedVariablesValueEqual(input, []);
+        });
+
+        it('Negating a non-existent result evaluates to true', () => {
             const input = `
                 #if !exists( UNSET_ENV_VAR )
                     .Value = true
@@ -5181,7 +5200,7 @@ Expecting to see the following:
                 #undef MY_UNDEFINED_DEFINE
             `;
             const expectedErrorMessage = `Cannot #undef undefined symbol "MY_UNDEFINED_DEFINE".`;
-            assertEvaluationError(input, expectedErrorMessage, createParseRange(1, 23, 1, 42));
+            assertEvaluationError(input, expectedErrorMessage, createParseRange(1, 16, 1, 42));
         });
 
         it('undefining a built-in symbol is an error', () => {
@@ -5190,7 +5209,7 @@ Expecting to see the following:
                 #undef ${builtInDefine}
             `;
             const expectedErrorMessage = `Cannot #undef built-in symbol "${builtInDefine}".`;
-            assertEvaluationError(input, expectedErrorMessage, createParseRange(1, 23, 1, 23 + builtInDefine.length));
+            assertEvaluationError(input, expectedErrorMessage, createParseRange(1, 16, 1, 23 + builtInDefine.length));
         });
     });
 
@@ -5234,7 +5253,7 @@ Expecting to see the following:
                 #import UNSET_ENV_VAR
             `;
             const expectedErrorMessage = `Cannot import environment variable "UNSET_ENV_VAR" because it does not exist.`;
-            assertEvaluationError(input, expectedErrorMessage, createParseRange(1, 24, 1, 37));
+            assertEvaluationError(input, expectedErrorMessage, createParseRange(1, 16, 1, 37));
         });
     });
 });


### PR DESCRIPTION
Fixes #23