### PR TITLE
Stop returning duplicates for "get document/workspace symbols"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.7
+
+## Changes
+
+* [#32] Stop returning duplicates for "get document/workspace symbols". This makes the results more usable. Additionally, in experiments on a large code base, this makes "get workspace symbols" twice as fast.
+
 # v0.5.6
 
 ## Bug fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/features/referenceProvider.ts
+++ b/server/src/features/referenceProvider.ts
@@ -92,7 +92,10 @@ export class ReferenceProvider {
         const uri = params.textDocument.uri;
         const symbols: DocumentSymbol[] = [];
 
+        //
         // Add targets
+        //
+
         for (const [name, definition] of evaluatedData.targetDefinitions) {
             if (definition.range.uri !== uri) {
                 continue;
@@ -107,11 +110,30 @@ export class ReferenceProvider {
             symbols.push(symbol);
         }
 
+        //
         // Add variables
+        //
+
+        // Set of hashed symbols, to deduplicate results.
+        //
+        // These occur when a variable is defined with the same place multiple times.
+        // For example, from a loop or from a file being `#include`d multiple times.
+        //
+        // This is not necessary for targets, since there cannot be duplicate target names.
+        const ranges = new Set<string>();
+
         for (const definition of evaluatedData.variableDefinitions) {
             if (definition.range.uri !== uri) {
                 continue;
             }
+
+            // Avoid returning multiple of the same symbol.
+            // This assumes that symbols with the same range are the same.
+            const symbolHash = JSON.stringify(definition.range);
+            if (ranges.has(symbolHash)) {
+                continue;
+            }
+            ranges.add(symbolHash);
 
             const symbol: DocumentSymbol = {
                 name: definition.name,

--- a/server/src/features/referenceProvider.ts
+++ b/server/src/features/referenceProvider.ts
@@ -150,7 +150,10 @@ export class ReferenceProvider {
     getWorkspaceSymbols(params: WorkspaceSymbolParams, evaluatedDatas: IterableIterator<EvaluatedData>): SymbolInformation[] | null {
         const symbols: SymbolInformation[] = [];
         for (const evaluatedData of evaluatedDatas) {
+            //
             // Add targets
+            //
+
             for (const [name, definition] of evaluatedData.targetDefinitions) {
                 if (!fuzzy.test(params.query, name)) {
                     continue;
@@ -167,11 +170,31 @@ export class ReferenceProvider {
                 symbols.push(symbol);
             }
 
+
+            //
             // Add variables
+            //
+
+            // Set of hashed symbols, to deduplicate results.
+            //
+            // These occur when a variable is defined with the same place multiple times.
+            // For example, from a loop or from a file being `#include`d multiple times.
+            //
+            // This is not necessary for targets, since there cannot be duplicate target names.
+            const ranges = new Set<string>();
+
             for (const definition of evaluatedData.variableDefinitions) {
                 if (!fuzzy.test(params.query, definition.name)) {
                     continue;
                 }
+
+                // Avoid returning multiple of the same symbol.
+                // This assumes that symbols with the same range are the same.
+                const symbolHash = JSON.stringify(definition.range);
+                if (ranges.has(symbolHash)) {
+                    continue;
+                }
+                ranges.add(symbolHash);
 
                 const symbol: SymbolInformation = {
                     name: definition.name,


### PR DESCRIPTION
Experimentally, this makes the operation twice as fast.

Contributes to #28, but does not resolve it entirely.