### PR TITLE
Fix bug where long hover values were truncated incorrectly (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+# v0.5.9
+
+## Bug Fixes
+
+* ([#38](https://github.com/harrisont/fastbuild-vscode/issues/38)) Fix a bug where very long (>100,000 characters) evaluated variable hover values don't render correctly, because VS Code truncates them. Now the extension truncates them before hitting the limit, so it still renders correctly.
+
 # v0.5.8
 
 ## Bug Fixes
 
-* ([#31](https://github.com/harrisont/fastbuild-vscode/issues/4)) Fix a bug where the `ForEach` loop variable did not appear on hover or on "go to document symbols".
+* ([#31](https://github.com/harrisont/fastbuild-vscode/issues/31)) Fix a bug where the `ForEach` loop variable did not appear on hover or on "go to document symbols".
 
 # v0.5.7
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.5.8",
+	"version": "0.5.9",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/test/3-hoversProvider.test.ts
+++ b/server/src/test/3-hoversProvider.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../evaluator';
 
 import {
+    getHoverText,
     valueToString,
 } from '../features/hoversProvider';
 
@@ -145,6 +146,79 @@ describe('hoversProvider', () => {
     ]
 ]`,
                 str);
+        });
+    });
+
+    describe('getHoverText', () => {
+        it('works for a single value', () => {
+            const actualHoverText = getHoverText(new Set<Value>([
+                'a',
+            ]));
+            const expectedHoverText = `\`\`\`fastbuild
+"a"
+\`\`\``;
+            assert.strictEqual(actualHoverText, expectedHoverText);
+        });
+
+        it('works for multiple values', () => {
+            const actualHoverText = getHoverText(new Set<Value>([
+                'a',
+                'b',
+            ]));
+            const expectedHoverText = `\`\`\`fastbuild
+Values:
+"a"
+"b"
+\`\`\``;
+            assert.strictEqual(actualHoverText, expectedHoverText);
+        });
+
+        it('deduplicates identical values', () => {
+            const actualHoverText = getHoverText(new Set<Value>([
+                'a',
+                'a',
+            ]));
+            const expectedHoverText = `\`\`\`fastbuild
+"a"
+\`\`\``;
+            assert.strictEqual(actualHoverText, expectedHoverText);
+        });
+
+        it('works for a single value that is longer than VS Code supports (>100,000 characters), by truncating the result', () => {
+            const strWithLengthOverLimit = 'a'.repeat(200000);
+            const actualHoverText = getHoverText(new Set<Value>([
+                strWithLengthOverLimit,
+            ]));
+
+            // Need extra characters for the prefix, ellipsis, and the suffix.
+            const expectedHoverTextWithoutValue = `\`\`\`fastbuild
+"…
+\`\`\``;
+            const expectedValueStrLenth = 100000 - expectedHoverTextWithoutValue.length;
+            const expectedTruncatedStr = 'a'.repeat(expectedValueStrLenth);
+            const expectedHoverText = `\`\`\`fastbuild
+"${expectedTruncatedStr}…
+\`\`\``;
+            assert.strictEqual(actualHoverText.length <= 100000, true);
+            assert.strictEqual(actualHoverText.length, expectedHoverText.length);
+            assert.strictEqual(actualHoverText, expectedHoverText);
+        });
+
+        it('works for multiple values that combined are longer than VS Code supports (>100,000 characters), by skipping the possible value that would push over the limit', () => {
+            const strWithLengthHalfOfLimit1 = 'a'.repeat(50000);
+            const strWithLengthHalfOfLimit2 = 'b'.repeat(50000);
+            const actualHoverText = getHoverText(new Set<Value>([
+                strWithLengthHalfOfLimit1,
+                strWithLengthHalfOfLimit2,
+            ]));
+            const expectedHoverText = `\`\`\`fastbuild
+Values:
+"${strWithLengthHalfOfLimit1}"
+…
+\`\`\``;
+            assert.strictEqual(actualHoverText.length <= 100000, true);
+            assert.strictEqual(actualHoverText.length, expectedHoverText.length);
+            assert.strictEqual(actualHoverText, expectedHoverText);
         });
     });
 });


### PR DESCRIPTION
Fix a bug where very long (>100,000 characters) evaluated variable hover values don't render correctly, because VS Code truncates them. Now the extension truncates them before hitting the limit, so it still renders correctly.

Fixes #38.

Screenshot of the new appearance:
![image](https://user-images.githubusercontent.com/144260/230692735-379d5460-3749-400c-a8cd-80576ecae801.png)
