### PR TITLE
Allow escaping all characters, not just `^`, `$`, `'`, and `"`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.9.4
+
+## Bug Fixes
+
+* ([#52](https://github.com/harrisont/fastbuild-vscode/issues/52)) Allow escaping all characters, not just `^`, `$`, `'`, and `"`.
+
 # v0.9.3
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/fbuild-grammar.ne
+++ b/server/src/fbuild-grammar.ne
@@ -96,27 +96,27 @@ const lexer = moo.states({
     singleQuotedStringBodyThenPop: {
         startTemplatedVariable: { match: '$', push: 'templatedVariable' },
         singleQuotedStringEnd: { match: "'", pop: 1 },
-        // Handle escaping ', $, ^ with ^
-        stringLiteral: /(?:[^'$^\r\n]|\^['$^])+/,
+        // Handle escaping with ^
+        stringLiteral: /(?:[^'$^\r\n]|\^.)+/,
     },
     doubleQuotedStringBodyThenPop: {
         startTemplatedVariable: { match: '$', push: 'templatedVariable' },
         doubleQuotedStringEnd: { match: '"', pop: 1 },
-        // Handle escaping ", $, ^ with ^
-        stringLiteral: /(?:[^"$^\r\n]|\^["$^])+/,
+        // Handle escaping with ^
+        stringLiteral: /(?:[^"$^\r\n]|\^.)+/,
     },
     // Same as "...ThenPop" but instead of popping, goes to "main".
     singleQuotedStringBodyThenMain: {
         startTemplatedVariable: { match: '$', push: 'templatedVariable' },
         singleQuotedStringEnd: { match: "'", next: 'main' },
-        // Handle escaping ', $, ^ with ^
-        stringLiteral: /(?:[^'$^\r\n]|\^['$^])+/,
+        // Handle escaping with ^
+        stringLiteral: /(?:[^'$^\r\n]|\^.)+/,
     },
     doubleQuotedStringBodyThenMain: {
         startTemplatedVariable: { match: '$', push: 'templatedVariable' },
         doubleQuotedStringEnd: { match: '"', next: 'main' },
-        // Handle escaping ", $, ^ with ^
-        stringLiteral: /(?:[^"$^\r\n]|\^["$^])+/,
+        // Handle escaping with ^
+        stringLiteral: /(?:[^"$^\r\n]|\^.)+/,
     },
     templatedVariable: {
         endTemplatedVariable: { match: '$', pop: 1 },

--- a/server/src/test/1-parser.test.ts
+++ b/server/src/test/1-parser.test.ts
@@ -577,6 +577,29 @@ describe('parser', () => {
         ]);
     });
 
+    it('should work on assigning a string literal with an escaped character that does not need to be escaped', () => {
+        const input = `.MyVar = 'h^i'`;
+        assertParseResultsEqual(input, [
+            {
+                type: 'variableDefinition',
+                lhs: {
+                    name: {
+                        type: 'string',
+                        value: 'MyVar',
+                        range: createRange(0, 1, 0, 6)
+                    },
+                    scope: 'current',
+                    range: createRange(0, 0, 0, 6),
+                },
+                rhs: {
+                    type: 'string',
+                    value: 'hi',
+                    range: createRange(0, 9, 0, 14)
+                }
+            }
+        ]);
+    });
+
     it('should work on assigning a single quoted string with a variable', () => {
         const input = `.MyVar = 'pre-$OtherVar$-post'`;
         assertParseResultsEqual(input, [


### PR DESCRIPTION
Fixes #52