### PR TITLE
Add a test for "go to references" supporting multiple references with the same location but to different definitions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
-			"preLaunchTask": "watch-build"
+			"preLaunchTask": "build"
 		},
 		{
 			"name": "Attach to Server",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
 	},
 	"search.exclude": {
 		"**/out": true
-	}
+	},
+	"editor.renderFinalNewline": "dimmed",
+	"files.insertFinalNewline": true
 }

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -93,7 +93,7 @@ function evaluateInputs(thisFbuildUriStr: UriStr, inputs: Map<UriStr, FileConten
     return evaluatedStatementsAndMaybeError.data;
 }
 
-function evaluateInput(input: FileContents, enableDiagnostics: boolean): EvaluatedData {
+export function evaluateInput(input: FileContents, enableDiagnostics: boolean): EvaluatedData {
     const thisFbuildUri = 'file:///dummy.bff';
     return evaluateInputs(thisFbuildUri, new Map<UriStr, FileContents>([[thisFbuildUri, input]]), enableDiagnostics);
 }

--- a/server/src/test/4-referenceProvider.test.ts
+++ b/server/src/test/4-referenceProvider.test.ts
@@ -3,32 +3,200 @@ import * as referenceProvider from '../features/referenceProvider';
 import { evaluateInput } from './2-evaluator.test';
 import {
     Location,
+    Position,
     ReferenceParams,
 } from 'vscode-languageserver-protocol';
 
+function createLocation(startLine: number, startCharacter: number, endCharacter: number): Location {
+    return {
+        uri: 'file:///dummy.bff',
+        range: {
+            start: {
+                line: startLine,
+                character: startCharacter,
+            },
+            end: {
+                line: startLine,
+                character: endCharacter,
+            },
+        }
+    };
+}
+
+function getReferences(input: string, position: Position): Location[] {
+    const evaluatedData = evaluateInput(input, true /*enableDiagnostics*/);
+    const referenceParams: ReferenceParams = {
+        context: {
+            includeDeclaration: true,
+        },
+        textDocument: {
+            uri: 'file:///dummy.bff',
+        },
+        position,
+    };
+    return referenceProvider.getReferences(referenceParams, evaluatedData);
+}
+
 describe('referenceProvider', () => {
     describe('getReferences', () => {
-        it('assigning a new variable creates a definition, but assigning an existing variable does not', () => {
+        it('works for a basic reference', () => {
             const input = `
-                TODO
+                .A = 1
+                Print( .A )
             `;
-            const evaluatedData = evaluateInput(input, true /*enableDiagnostics*/);
-            const referenceParams: ReferenceParams = {
-                context: {
-                    includeDeclaration: true,
-                },
-                textDocument: {
-                    uri: 'TODO',
-                },
-                position: {
-                    line: 0,
-                    character: 0,
-                },
-            };
-            const actualReferences = referenceProvider.getReferences(referenceParams, evaluatedData);
+            // The position of the `.` in `Print( .A )`
+            const lookupPosition = Position.create(2, 23);
+            const actualReferences = getReferences(input, lookupPosition);
 
             const expectedReferences: Location[] = [
+                // The `.A` in `.A = 1`
+                createLocation(1, 16, 18),
+                // The `.A` in `Print( .A )`
+                createLocation(2, 23, 25),
             ];
+
+            assert.deepStrictEqual(actualReferences, expectedReferences);
+        });
+
+        it('works for a struct field defined from a `Using`', () => {
+            const input = `
+                .MyStruct = [
+                    .A = 1
+                ]
+                Using( .MyStruct )
+                Print( .A )
+            `;
+            // The position of the `.` in `Print( .A )`
+            const lookupPosition = Position.create(5, 23);
+            const actualReferences = getReferences(input, lookupPosition);
+
+            const expectedReferences: Location[] = [
+                // The definition of A in `Using( .MyStruct )`
+                createLocation(4, 16, 34),
+                // The `.A` in `.A = 1`
+                createLocation(2, 20, 22),
+                // The `.A` in `Print( .A )`
+                createLocation(5, 23, 25),
+            ];
+
+            assert.deepStrictEqual(actualReferences, expectedReferences);
+        });
+
+        it('works for a struct used by a `Using`', () => {
+            const input = `
+                .MyStruct = [
+                    .A = 1
+                ]
+                Using( .MyStruct )
+                Print( .A )
+            `;
+            // The position of the `.` in `Using( .MyStruct )`
+            const lookupPosition = Position.create(4, 23);
+            const actualReferences = getReferences(input, lookupPosition);
+
+            // The position overlaps:
+            //  * the visible reference to MyStruct
+            //  * the invisible definition and reference to the struct's fields (A).
+            // So getting references gets the references to both, and not just references to MyStruct.
+            const expectedReferences: Location[] = [
+                // The `.A` in `.A = 1`
+                createLocation(2, 20, 22),
+                // The `.MyStruct` in `.MyStruct = [`
+                createLocation(1, 16, 25),
+                // The `.MyStruct` in `Using( .MyStruct )`
+                createLocation(4, 23, 32),
+                // The definition of A in `Using( .MyStruct )`
+                createLocation(4, 16, 34),
+                // The `.A` in `Print( .A )`
+                createLocation(5, 23, 25),
+            ];
+
+            assert.deepStrictEqual(actualReferences, expectedReferences);
+        });
+
+        it('works for a struct field defined from a `Using` in a `ForEach`', () => {
+            const input = `
+                .MyStruct1 = [
+                    .A = 1
+                ]
+
+                .MyStruct2 = [
+                    .A = 2
+                ]
+
+                .MyStructs = {
+                    .MyStruct1
+                    .MyStruct2
+                }
+
+                ForEach( .MyStruct in .MyStructs )
+                {
+                    Using( .MyStruct )
+                    Print( .A )
+                }
+            `;
+            // The position of the `.` in `Print( .A )`
+            const lookupPosition = Position.create(17, 27);
+            const actualReferences = getReferences(input, lookupPosition);
+
+            const expectedReferences: Location[] = [
+                // The definition of A in `Using( .MyStruct )`
+                createLocation(16, 20, 38),
+                // The `.A` in `.A = 1`
+                createLocation(2, 20, 22),
+                // The `.A` in `Print( .A )`
+                createLocation(17, 27, 29),
+                // The `.A` in `.A = 2`
+                createLocation(6, 20, 22),
+            ];
+
+            assert.deepStrictEqual(actualReferences, expectedReferences);
+        });
+
+        it('works for a struct used by a `Using` in a `ForEach`', () => {
+            const input = `
+                .MyStruct1 = [
+                    .A = 1
+                ]
+
+                .MyStruct2 = [
+                    .A = 2
+                ]
+
+                .MyStructs = {
+                    .MyStruct1
+                    .MyStruct2
+                }
+
+                ForEach( .MyStruct in .MyStructs )
+                {
+                    Using( .MyStruct )
+                    Print( .A )
+                }
+            `;
+            // The position of the `.` in `Using( .MyStruct )`
+            const lookupPosition = Position.create(16, 27);
+            const actualReferences = getReferences(input, lookupPosition);
+
+            // The position overlaps:
+            //  * the visible reference to MyStruct
+            //  * the invisible definition and reference to the struct's fields (A).
+            // So getting references gets the references to both, and not just references to MyStruct.
+            const expectedReferences: Location[] = [
+                // The `.A` in `.A = 1`
+                createLocation(2, 20, 22),
+                // The `.A` in `.A = 2`
+                createLocation(6, 20, 22),
+                // The `.MyStruct` in `ForEach( .MyStruct in .MyStructs )`
+                createLocation(14, 25, 34),
+                // The `.MyStruct` in `Using( .MyStruct )`
+                createLocation(16, 27, 36),
+                // The definition of A in `Using( .MyStruct )`
+                createLocation(16, 20, 38),
+                // The `.A` in `Print( .A )`
+                createLocation(17, 27, 29),
+            ];
+
             assert.deepStrictEqual(actualReferences, expectedReferences);
         });
     });

--- a/server/src/test/4-referenceProvider.test.ts
+++ b/server/src/test/4-referenceProvider.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import * as referenceProvider from '../features/referenceProvider';
+import { evaluateInput } from './2-evaluator.test';
+import {
+    Location,
+    ReferenceParams,
+} from 'vscode-languageserver-protocol';
+
+describe('referenceProvider', () => {
+    describe('getReferences', () => {
+        it('assigning a new variable creates a definition, but assigning an existing variable does not', () => {
+            const input = `
+                TODO
+            `;
+            const evaluatedData = evaluateInput(input, true /*enableDiagnostics*/);
+            const referenceParams: ReferenceParams = {
+                context: {
+                    includeDeclaration: true,
+                },
+                textDocument: {
+                    uri: 'TODO',
+                },
+                position: {
+                    line: 0,
+                    character: 0,
+                },
+            };
+            const actualReferences = referenceProvider.getReferences(referenceParams, evaluatedData);
+
+            const expectedReferences: Location[] = [
+            ];
+            assert.deepStrictEqual(actualReferences, expectedReferences);
+        });
+    });
+});


### PR DESCRIPTION
This tests the changes in PR #51.
It also adds general "go to references" tests.

Closes issue #50.