### PR TITLE
Make "go to definition" on a variable created by `Using` also show the definition from the `Using`'s struct's field.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
-			"preLaunchTask": "build"
+			"preLaunchTask": "watch-build"
 		},
 		{
 			"name": "Attach to Server",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.10.0
+
+## New Features
+
+* ([#54](https://github.com/harrisont/fastbuild-vscode/issues/54)) "Go to definition" on a variable created by `Using` now also includes the definition from the `Using`'s struct's field. This makes it easier to find the origin of the field's value. Note that this was already possible using "go to references", just not using "go to definition".
+
 # v0.9.4
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.9.4",
+	"version": "0.10.0",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/evaluator.ts
+++ b/server/src/evaluator.ts
@@ -129,7 +129,7 @@ export interface VariableDefinition {
 }
 
 export interface VariableReference {
-    definition: VariableDefinition;
+    definitions: VariableDefinition[];
     range: SourceRange;
 }
 
@@ -972,7 +972,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
 
                 // The definition's LHS is a variable reference.
                 context.evaluatedData.variableReferences.push({
-                    definition: variable.definition,
+                    definitions: [variable.definition],
                     range: lhsRange,
                 });
 
@@ -1044,7 +1044,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
 
                 // The LHS is a variable reference.
                 context.evaluatedData.variableReferences.push({
-                    definition: lhsVariable.definition,
+                    definitions: [lhsVariable.definition],
                     range: lhsRange,
                 });
 
@@ -1144,15 +1144,15 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
 
                     context.evaluatedData.variableReferences.push(
                         {
-                            definition: variableDefinition,
+                            definitions: [variableDefinition],
                             range: statementRange,
                         },
                         {
-                            definition: structMember.definition,
+                            definitions: [structMember.definition],
                             range: statementRange,
                         },
                         {
-                            definition: variableDefinition,
+                            definitions: [variableDefinition],
                             range: structMember.definition.range,
                         }
                     );
@@ -1204,7 +1204,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     // The loop variable is a definition and a reference.
                     context.evaluatedData.variableDefinitions.push(loopVarDefinition);
                     context.evaluatedData.variableReferences.push({
-                        definition: loopVarDefinition,
+                        definitions: [loopVarDefinition],
                         range: loopVarRange,
                     });
 
@@ -1432,7 +1432,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                 };
                 context.defines.set(symbol, info);
                 const reference: VariableReference = {
-                    definition,
+                    definitions: [definition],
                     range: statementRange,
                 };
                 context.evaluatedData.variableReferences.push(reference);
@@ -1459,7 +1459,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                 context.scopeStack.setVariableInCurrentScope(symbolName, environmentVariableValue, definition);
 
                 const reference: VariableReference = {
-                    definition,
+                    definitions: [definition],
                     range: statementRange,
                 };
                 context.evaluatedData.variableReferences.push(reference);
@@ -1633,7 +1633,7 @@ function evaluateEvaluatedVariable(parsedEvaluatedVariable: ParsedEvaluatedVaria
     });
 
     context.evaluatedData.variableReferences.push({
-        definition: valueScopeVariable.definition,
+        definitions: [valueScopeVariable.definition],
         range: parsedEvaluatedVariableRange,
     });
 
@@ -2025,7 +2025,7 @@ function evaluateDirectiveIfCondition(
                 evaulatedTerm = (info !== undefined);
                 if (info !== undefined && !info.isPredefined) {
                     const reference: VariableReference = {
-                        definition: info.definition,
+                        definitions: [info.definition],
                         range: termRange,
                     };
                     context.evaluatedData.variableReferences.push(reference);
@@ -2068,8 +2068,8 @@ function evaluateUserFunctionDeclaration(
 ): Error | null {
     const nameSourceRange = new SourceRange(context.thisFbuildUri, userFunction.nameRange);
     const functionNameDefinition = context.scopeStack.createVariableDefinition(nameSourceRange, userFunction.name);
-    const functionNameReference = {
-        definition: functionNameDefinition,
+    const functionNameReference: VariableReference = {
+        definitions: [functionNameDefinition],
         range: nameSourceRange,
     };
 
@@ -2104,7 +2104,7 @@ function evaluateUserFunctionDeclaration(
 
         context.evaluatedData.variableDefinitions.push(definition);
         context.evaluatedData.variableReferences.push({
-            definition: definition,
+            definitions: [definition],
             range: paramSourceRange,
         });
     }
@@ -2132,7 +2132,7 @@ function evaluateUserFunctionCall(
 
     // Reference the function.
     context.evaluatedData.variableReferences.push({
-        definition: userFunction.definition,
+        definitions: [userFunction.definition],
         range: nameSourceRange,
     });
 

--- a/server/src/evaluator.ts
+++ b/server/src/evaluator.ts
@@ -53,7 +53,7 @@ export type Value = boolean | number | string | Value[] | Struct;
 export type VariableName = string;
 
 export class StructMember {
-    constructor(readonly value: Value, readonly definition: VariableDefinition) {
+    constructor(readonly value: Value, readonly definitions: VariableDefinition[]) {
     }
 }
 
@@ -634,7 +634,7 @@ interface UserFunction {
 
 interface ScopeVariable {
     value: Value;
-    definition: VariableDefinition;
+    definitions: VariableDefinition[];
 }
 
 class Scope {
@@ -756,13 +756,13 @@ class ScopeStack {
         }
     }
 
-    setVariableInCurrentScope(name: string, value: Value, definition: VariableDefinition): ScopeVariable {
+    setVariableInCurrentScope(name: string, value: Value, definitions: VariableDefinition[]): ScopeVariable {
         const currentScope = this.getCurrentScope();
         const existingVariable = currentScope.variables.get(name);
         if (existingVariable === undefined) {
             const variable: ScopeVariable = {
                 value: value,
-                definition: definition,
+                definitions,
             };
             currentScope.variables.set(name, variable);
             return variable;
@@ -852,10 +852,10 @@ function createDefaultScopeStack(rootFbuildDirUri: vscodeUri.URI): ScopeStack {
         return definition;
     };
 
-    scopeStack.setVariableInCurrentScope('_WORKING_DIR_', rootFbuildDirUri.fsPath, createNoLocationVariableDefinition('_WORKING_DIR_'));
-    scopeStack.setVariableInCurrentScope('_CURRENT_BFF_DIR_', '', createNoLocationVariableDefinition('_CURRENT_BFF_DIR_'));
-    scopeStack.setVariableInCurrentScope('_FASTBUILD_VERSION_STRING_', 'vPlaceholderFastBuildVersionString', createNoLocationVariableDefinition('_FASTBUILD_VERSION_STRING_'));
-    scopeStack.setVariableInCurrentScope('_FASTBUILD_VERSION_', -1, createNoLocationVariableDefinition('_FASTBUILD_VERSION_'));
+    scopeStack.setVariableInCurrentScope('_WORKING_DIR_', rootFbuildDirUri.fsPath, [createNoLocationVariableDefinition('_WORKING_DIR_')]);
+    scopeStack.setVariableInCurrentScope('_CURRENT_BFF_DIR_', '', [createNoLocationVariableDefinition('_CURRENT_BFF_DIR_')]);
+    scopeStack.setVariableInCurrentScope('_FASTBUILD_VERSION_STRING_', 'vPlaceholderFastBuildVersionString', [createNoLocationVariableDefinition('_FASTBUILD_VERSION_STRING_')]);
+    scopeStack.setVariableInCurrentScope('_FASTBUILD_VERSION_', -1, [createNoLocationVariableDefinition('_FASTBUILD_VERSION_')]);
 
     return scopeStack;
 }
@@ -933,11 +933,11 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     }
 
                     const definition = context.scopeStack.createVariableDefinition(lhsRange, evaluatedLhsName.value);
-                    variable = context.scopeStack.setVariableInCurrentScope(evaluatedLhsName.value, value, definition);
+                    variable = context.scopeStack.setVariableInCurrentScope(evaluatedLhsName.value, value, [definition]);
 
                     if (existingVariable === null) {
                         // The definition's LHS is a variable definition.
-                        context.evaluatedData.variableDefinitions.push(variable.definition);
+                        context.evaluatedData.variableDefinitions.push(definition);
                     }
                 } else {
                     const maybeVariable = context.scopeStack.getVariableStartingFromParentScopeOrError(evaluatedLhsName.value, lhsRange);
@@ -972,7 +972,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
 
                 // The definition's LHS is a variable reference.
                 context.evaluatedData.variableReferences.push({
-                    definitions: [variable.definition],
+                    definitions: variable.definitions,
                     range: lhsRange,
                 });
 
@@ -1011,7 +1011,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     const previousValue = maybeExistingVariableStartingFromParentScope.value;
                     const definition = context.scopeStack.createVariableDefinition(lhsRange, evaluatedLhsName.value);
                     context.evaluatedData.variableDefinitions.push(definition);
-                    lhsVariable = context.scopeStack.setVariableInCurrentScope(evaluatedLhsName.value, previousValue, definition);
+                    lhsVariable = context.scopeStack.setVariableInCurrentScope(evaluatedLhsName.value, previousValue, [definition]);
                 } else {
                     const maybeExistingVariable = context.scopeStack.getVariableInScopeOrError(lhs.scope, evaluatedLhsName.value, lhsRange);
                     if (maybeExistingVariable.hasError) {
@@ -1044,7 +1044,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
 
                 // The LHS is a variable reference.
                 context.evaluatedData.variableReferences.push({
-                    definitions: [lhsVariable.definition],
+                    definitions: lhsVariable.definitions,
                     range: lhsRange,
                 });
 
@@ -1130,32 +1130,34 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                 //       * the current scope's variable-from-member's definition from the member's definition
 
                 for (const [structMemberName, structMember] of struct.members) {
-                    // The definition will only be used if the variable does not already exist in the current scope.
-                    let variableDefinition: VariableDefinition;
+                    let variableDefinitions: VariableDefinition[];
                     const existingVariable = context.scopeStack.getVariableInCurrentScope(structMemberName);
                     if (existingVariable !== null) {
                         existingVariable.value = structMember.value;
-                        variableDefinition = existingVariable.definition;
+                        variableDefinitions = existingVariable.definitions;
                     } else {
-                        variableDefinition = context.scopeStack.createVariableDefinition(statementRange, structMemberName);
-                        context.scopeStack.setVariableInCurrentScope(structMemberName, structMember.value, variableDefinition);
-                        context.evaluatedData.variableDefinitions.push(variableDefinition);
+                        const newDefinition = context.scopeStack.createVariableDefinition(statementRange, structMemberName);
+                        variableDefinitions = structMember.definitions.concat(newDefinition);
+                        context.scopeStack.setVariableInCurrentScope(structMemberName, structMember.value, variableDefinitions);
+                        context.evaluatedData.variableDefinitions.push(newDefinition);
                     }
 
                     context.evaluatedData.variableReferences.push(
                         {
-                            definitions: [variableDefinition],
+                            definitions: variableDefinitions,
                             range: statementRange,
                         },
                         {
-                            definitions: [structMember.definition],
+                            definitions: structMember.definitions,
                             range: statementRange,
                         },
-                        {
-                            definitions: [variableDefinition],
-                            range: structMember.definition.range,
-                        }
                     );
+                    for (const structMemberDefinition of structMember.definitions) {
+                        context.evaluatedData.variableReferences.push({
+                            definitions: variableDefinitions,
+                            range: structMemberDefinition.range,
+                        });
+                    }
                 }
             } else if (isParsedStatementForEach(statement)) {
                 // Evaluate the iterators (array to loop over plus the loop-variable)
@@ -1209,7 +1211,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     });
 
                     // Set a variable in the current scope for each iterator's loop variable.
-                    const loopVariable = context.scopeStack.setVariableInCurrentScope(evaluatedLoopVarNameValue, 0, loopVarDefinition);
+                    const loopVariable = context.scopeStack.setVariableInCurrentScope(evaluatedLoopVarNameValue, 0, [loopVarDefinition]);
                     iterators.push({
                         loopVariable,
                         arrayItems,
@@ -1456,7 +1458,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     return new EvaluationError(statementRange, `Cannot import environment variable "${symbolName}" because it does not exist.`);
                 }
                 const definition = context.scopeStack.createVariableDefinition(statementRange, symbolName);
-                context.scopeStack.setVariableInCurrentScope(symbolName, environmentVariableValue, definition);
+                context.scopeStack.setVariableInCurrentScope(symbolName, environmentVariableValue, [definition]);
 
                 const reference: VariableReference = {
                     definitions: [definition],
@@ -1633,7 +1635,7 @@ function evaluateEvaluatedVariable(parsedEvaluatedVariable: ParsedEvaluatedVaria
     });
 
     context.evaluatedData.variableReferences.push({
-        definitions: [valueScopeVariable.definition],
+        definitions: valueScopeVariable.definitions,
         range: parsedEvaluatedVariableRange,
     });
 
@@ -1679,7 +1681,7 @@ function evaluateStruct(struct: ParsedStruct, context: EvaluationContext): Maybe
 
     const structMembers = new Map<VariableName, StructMember>();
     for (const [name, variable] of structScope.variables) {
-        structMembers.set(name, new StructMember(variable.value, variable.definition));
+        structMembers.set(name, new StructMember(variable.value, variable.definitions));
     }
     const evaluatedValue = new Struct(structMembers);
 
@@ -2245,7 +2247,7 @@ function deepCopyValue(value: Value): Value {
         const structMembers = new Map<VariableName, StructMember>(
             Array.from(
                 value.members,
-                ([memberName, member]) => [memberName, new StructMember(deepCopyValue(member.value), member.definition)]));
+                ([memberName, member]) => [memberName, new StructMember(deepCopyValue(member.value), member.definitions)]));
         return new Struct(structMembers);
     } else {
         return value;

--- a/server/src/evaluator.ts
+++ b/server/src/evaluator.ts
@@ -1163,6 +1163,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                 // Evaluate the iterators (array to loop over plus the loop-variable)
                 interface ForEachIterator {
                     loopVariable: ScopeVariable;
+                    loopVariableRange: SourceRange;
                     arrayItems: Value[];
                 }
                 const iterators: ForEachIterator[] = [];
@@ -1214,11 +1215,12 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
                     const loopVariable = context.scopeStack.setVariableInCurrentScope(evaluatedLoopVarNameValue, 0, [loopVarDefinition]);
                     iterators.push({
                         loopVariable,
+                        loopVariableRange: loopVarRange,
                         arrayItems,
                     });
                 }
 
-                // Evaluate the function body.
+                // Evaluate the ForEach body.
 
                 let error: Error | null = null;
                 const arrayItemsLength = iterators[0].arrayItems.length;
@@ -1231,7 +1233,7 @@ function evaluateStatements(statements: Statement[], context: EvaluationContext)
 
                             context.evaluatedData.evaluatedVariables.push({
                                 value: arrayItem,
-                                range: iterator.loopVariable.definition.range,
+                                range: iterator.loopVariableRange,
                             });
                         }
 
@@ -2193,7 +2195,7 @@ function evaluateUserFunctionCall(
             }
 
             // Note that we set the variable in the function call context, not the current context.
-            functionCallContext.scopeStack.setVariableInCurrentScope(funcDeclarationParam.name, paramValues[i], funcDeclarationParam.definition);
+            functionCallContext.scopeStack.setVariableInCurrentScope(funcDeclarationParam.name, paramValues[i], [funcDeclarationParam.definition]);
         }
 
         error = evaluateStatements(userFunction.statements, functionCallContext);

--- a/server/src/features/definitionProvider.ts
+++ b/server/src/features/definitionProvider.ts
@@ -53,15 +53,16 @@ export function getDefinition(params: DefinitionParams, evaluatedData: Evaluated
         if (uri == reference.range.uri
             && isPositionInRange(position, reference.range))
         {
-            const definition = reference.definition;
-            const definitionRange = createRangeFromSourceRange(definition.range);
-            const definitionLink: DefinitionLink = {
-                originSelectionRange: createRangeFromSourceRange(reference.range),
-                targetUri: definition.range.uri,
-                targetRange: definitionRange,
-                targetSelectionRange: definitionRange,
-            };
-            results.set(JSON.stringify(definition.range), definitionLink);
+            for (const definition of reference.definitions) {
+                const definitionRange = createRangeFromSourceRange(definition.range);
+                const definitionLink: DefinitionLink = {
+                    originSelectionRange: createRangeFromSourceRange(reference.range),
+                    targetUri: definition.range.uri,
+                    targetRange: definitionRange,
+                    targetSelectionRange: definitionRange,
+                };
+                results.set(JSON.stringify(definition.range), definitionLink);
+            }
         }
     }
 

--- a/server/src/features/referenceProvider.ts
+++ b/server/src/features/referenceProvider.ts
@@ -89,7 +89,9 @@ function getVariableReferences(uri: string, position: Position, evaluatedData: E
 
     const definitionIdsAtPosition = references
         .filter(ref => (ref.range.uri == uri && isPositionInRange(position, ref.range)))
-        .map(ref => ref.definition.id);
+        .map(ref => ref.definitions)
+        .reduce((accumulator, currentValue) => accumulator.concat(currentValue))
+        .map(definition => definition.id);
     if (definitionIdsAtPosition.length === 0) {
         return [];
     }
@@ -102,7 +104,7 @@ function getVariableReferences(uri: string, position: Position, evaluatedData: E
 
     for (const reference of references)
     {
-        if (definitionIdsAtPosition.some(defnIdAtPos => (reference.definition.id === defnIdAtPos))) {
+        if (definitionIdsAtPosition.some(defnIdAtPos => (reference.definitions.some(refDef => (refDef.id === defnIdAtPos))))) {
             const location = createLocationFromSourceRange(reference.range);
             const key = JSON.stringify(location);
             locations.set(key, location);

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -2095,12 +2095,12 @@ describe('evaluator', () => {
                 MyEvaluatedVar: new StructMember('fun', [myStructMyEvaluatedVarDefinition]),
             }));
             const other = Struct.from(Object.entries({
-                MyBool: new StructMember(true, [usingMyStructMyBoolDefinition]),
-                MyInt: new StructMember(1, [usingMyStructMyIntDefinition]),
-                MyString: new StructMember('hello', [usingMyStructMyStringDefinition]),
-                MyEvaluatedVar: new StructMember('fun', [usingMyStructMyEvaluatedVarDefinition]),
+                MyBool: new StructMember(true, [myStructMyBoolDefinition, usingMyStructMyBoolDefinition]),
+                MyInt: new StructMember(1, [myStructMyIntDefinition, usingMyStructMyIntDefinition]),
+                MyString: new StructMember('hello', [myStructMyStringDefinition, usingMyStructMyStringDefinition]),
+                MyEvaluatedVar: new StructMember('fun', [myStructMyEvaluatedVarDefinition, usingMyStructMyEvaluatedVarDefinition]),
             }));
-            assertEvaluatedVariablesValueEqual(input, [
+            const expectedEvaluatedVariableValues = [
                 'fun',
                 true,
                 1,
@@ -2113,7 +2113,8 @@ describe('evaluator', () => {
                 myStruct,
                 // .Other = ...
                 other,
-            ]);
+            ];
+            assertEvaluatedVariablesValueEqual(input, expectedEvaluatedVariableValues);
         });
 
         // 'Using' defines the struct variables if they do not already exist,
@@ -2171,9 +2172,9 @@ describe('evaluator', () => {
                 { definitions: [definitionMyVar1], range: rangeUsingStatement },
                 { definitions: [definitionMyStructMyVar1], range: rangeUsingStatement },
                 { definitions: [definitionMyVar1], range: rangeMyStructMyVar1 },
-                { definitions: [definitionMyVar2], range: rangeUsingStatement },
+                { definitions: [definitionMyStructMyVar2, definitionMyVar2], range: rangeUsingStatement },
                 { definitions: [definitionMyStructMyVar2], range: rangeUsingStatement },
-                { definitions: [definitionMyVar2], range: rangeMyStructMyVar2 },
+                { definitions: [definitionMyStructMyVar2, definitionMyVar2], range: rangeMyStructMyVar2 },
             ];
             assert.deepStrictEqual(result.variableReferences, expectedReferences);
         });
@@ -2197,7 +2198,10 @@ describe('evaluator', () => {
                 MyInt: new StructMember(1, [myStruct1MyIntDefinition]),
             }));
             const myStruct2 = Struct.from(Object.entries({
-                MyInt: new StructMember(1, [usingMyStruct1MyIntDefinition]),
+                MyInt: new StructMember(1, [myStruct1MyIntDefinition, usingMyStruct1MyIntDefinition]),
+            }));
+            const myStruct3 = Struct.from(Object.entries({
+                MyInt: new StructMember(1, [myStruct1MyIntDefinition, usingMyStruct1MyIntDefinition, usingMyStruct2MyIntDefinition]),
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 1,
@@ -2210,9 +2214,7 @@ describe('evaluator', () => {
                 // Using( .MyStruct2 )
                 myStruct2,
                 // .MyStruct3 = ...
-                Struct.from(Object.entries({
-                    MyInt: new StructMember(1, [usingMyStruct2MyIntDefinition]),
-                }))
+                myStruct3,
             ]);
         });
 

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -1922,11 +1922,11 @@ describe('evaluator', () => {
             const result = evaluateInput(input, true /*enableDiagnostics*/);
             const expectedReferences: VariableReference[] = [
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 22),
                         name: 'MyVar',
-                    },
+                    }],
                     range: createRange(1, 16, 1, 22),
                 }
             ];
@@ -1941,19 +1941,19 @@ describe('evaluator', () => {
             const result = evaluateInput(input, true /*enableDiagnostics*/);
             const expectedReferences: VariableReference[] = [
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 22),
                         name: 'MyVar',
-                    },
+                    }],
                     range: createRange(1, 16, 1, 22),
                 },
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 22),
                         name: 'MyVar',
-                    },
+                    }],
                     range: createRange(2, 16, 2, 22),
                 }
             ];
@@ -1968,27 +1968,27 @@ describe('evaluator', () => {
             const result = evaluateInput(input, true /*enableDiagnostics*/);
             const expectedReferences: VariableReference[] = [
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 23),
                         name: 'MyVar1',
-                    },
+                    }],
                     range: createRange(1, 16, 1, 23),
                 },
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 23),
                         name: 'MyVar1',
-                    },
+                    }],
                     range: createRange(2, 26, 2, 33),
                 },
                 {
-                    definition: {
+                    definitions: [{
                         id: 2,
                         range: createRange(2, 16, 2, 23),
                         name: 'MyVar2',
-                    },
+                    }],
                     range: createRange(2, 16, 2, 23),
                 }
             ];
@@ -2003,27 +2003,27 @@ describe('evaluator', () => {
             const result = evaluateInput(input, true /*enableDiagnostics*/);
             const expectedReferences: VariableReference[] = [
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 23),
                         name: 'MyVar1',
-                    },
+                    }],
                     range: createRange(1, 16, 1, 23),
                 },
                 {
-                    definition: {
+                    definitions: [{
                         id: 1,
                         range: createRange(1, 16, 1, 23),
                         name: 'MyVar1',
-                    },
+                    }],
                     range: createRange(2, 27, 2, 35),
                 },
                 {
-                    definition: {
+                    definitions: [{
                         id: 2,
                         range: createRange(2, 16, 2, 23),
                         name: 'MyVar2',
-                    },
+                    }],
                     range: createRange(2, 16, 2, 23),
                 }
             ];
@@ -2157,23 +2157,23 @@ describe('evaluator', () => {
             ];
             assert.deepStrictEqual(result.variableDefinitions, expectedDefinitions);
 
-            const expectedReferences = [
+            const expectedReferences: VariableReference[] = [
                 // .MyVar1 = 0
-                { definition: definitionMyVar1, range: rangeMyVar1 },
+                { definitions: [definitionMyVar1], range: rangeMyVar1 },
                 // MyStruct's .MyVar1 = 1
-                { definition: definitionMyStructMyVar1, range: rangeMyStructMyVar1 },
+                { definitions: [definitionMyStructMyVar1], range: rangeMyStructMyVar1 },
                 // MyStruct's .MyVar2 = 1
-                { definition: definitionMyStructMyVar2, range: rangeMyStructMyVar2 },
+                { definitions: [definitionMyStructMyVar2], range: rangeMyStructMyVar2 },
                 // .MyStruct = ...
-                { definition: definitionMyStruct, range: rangeMyStruct },
+                { definitions: [definitionMyStruct], range: rangeMyStruct },
                 // Using( .MyStruct )
-                { definition: definitionMyStruct, range: rangeUsingStructVar },
-                { definition: definitionMyVar1, range: rangeUsingStatement },
-                { definition: definitionMyStructMyVar1, range: rangeUsingStatement },
-                { definition: definitionMyVar1, range: rangeMyStructMyVar1 },
-                { definition: definitionMyVar2, range: rangeUsingStatement },
-                { definition: definitionMyStructMyVar2, range: rangeUsingStatement },
-                { definition: definitionMyVar2, range: rangeMyStructMyVar2 },
+                { definitions: [definitionMyStruct], range: rangeUsingStructVar },
+                { definitions: [definitionMyVar1], range: rangeUsingStatement },
+                { definitions: [definitionMyStructMyVar1], range: rangeUsingStatement },
+                { definitions: [definitionMyVar1], range: rangeMyStructMyVar1 },
+                { definitions: [definitionMyVar2], range: rangeUsingStatement },
+                { definitions: [definitionMyStructMyVar2], range: rangeUsingStatement },
+                { definitions: [definitionMyVar2], range: rangeMyStructMyVar2 },
             ];
             assert.deepStrictEqual(result.variableReferences, expectedReferences);
         });
@@ -2497,27 +2497,27 @@ describe('evaluator', () => {
             const expectedReferences: VariableReference[] = [
                 // `.MyArray = {'a', 'b'}`
                 {
-                    definition: expectedDefinitionMyArray,
+                    definitions: [expectedDefinitionMyArray],
                     range: expectedDefinitionMyArray.range,
                 },
                 // `...in .MyArray`
                 {
-                    definition: expectedDefinitionMyArray,
+                    definitions: [expectedDefinitionMyArray],
                     range: createRange(2, 34, 2, 42),
                 },
                 // // `ForEach( .Item...`
                 {
-                    definition: expectedDefinitionItem,
+                    definitions: [expectedDefinitionItem],
                     range: expectedDefinitionItem.range,
                 },
                 // `Print( .Item )` for the 1st loop iteration
                 {
-                    definition: expectedDefinitionItem,
+                    definitions: [expectedDefinitionItem],
                     range: createRange(4, 27, 4, 32),
                 },
                 // `Print( .Item )` for the 2nd loop iteration
                 {
-                    definition: expectedDefinitionItem,
+                    definitions: [expectedDefinitionItem],
                     range: createRange(4, 27, 4, 32),
                 },
             ];
@@ -4597,12 +4597,12 @@ Expecting to see the following:
             const expectedVariableReferences: VariableReference[] = [
                 // helper.bff ".FromHelper = 1" LHS
                 {
-                    definition: definitionFromHelper,
+                    definitions: [definitionFromHelper],
                     range: createFileRange('file:///helper.bff', 1, 24, 1, 35),
                 },
                 // fbuild.bff "Print( .FromHelper )"
                 {
-                    definition: definitionFromHelper,
+                    definitions: [definitionFromHelper],
                     range: createFileRange('file:///fbuild.bff', 2, 31, 2, 42),
                 },
             ];
@@ -5266,17 +5266,17 @@ Expecting to see the following:
             const expectedReferences: VariableReference[] = [
                 // #define MY_DEFINE
                 {
-                    definition: expectedDefinitionMyDefine,
+                    definitions: [expectedDefinitionMyDefine],
                     range: expectedDefinitionMyDefine.range,
                 },
                 // #if MY_DEFINE
                 {
-                    definition: expectedDefinitionMyDefine,
+                    definitions: [expectedDefinitionMyDefine],
                     range: createRange(2, 20, 2, 29),
                 },
                 // .Result = true
                 {
-                    definition: expectedDefinitionResult,
+                    definitions: [expectedDefinitionResult],
                     range: expectedDefinitionResult.range,
                 },
             ];
@@ -5326,7 +5326,7 @@ Expecting to see the following:
             const expectedReferences: VariableReference[] = [
                 // #define MY_DEFINE
                 {
-                    definition: expectedDefinitionMyDefine,
+                    definitions: [expectedDefinitionMyDefine],
                     range: createRange(1, 16, 1, 33),
                 },
             ];
@@ -5371,12 +5371,12 @@ Expecting to see the following:
             const expectedReferences: VariableReference[] = [
                 // #import ${builtInEnvVar}
                 {
-                    definition: expectedDefinition,
+                    definitions: [expectedDefinition],
                     range: createRange(1, 16, 1, 24 + builtInEnvVar.length),
                 },
                 // Print( .${builtInEnvVar} )
                 {
-                    definition: expectedDefinition,
+                    definitions: [expectedDefinition],
                     range: createRange(2, 23, 2, 24 + builtInEnvVar.length),
                 },
             ];

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -563,9 +563,9 @@ describe('evaluator', () => {
                 123,
                 'Hello world!',
                 Struct.from(Object.entries({
-                    MyBool: new StructMember(true, myVarMyBoolDefinition),
-                    MyInt: new StructMember(123, myVarMyIntDefinition),
-                    MyStr: new StructMember('Hello world!', myVarMyStrDefinition),
+                    MyBool: new StructMember(true, [myVarMyBoolDefinition]),
+                    MyInt: new StructMember(123, [myVarMyIntDefinition]),
+                    MyStr: new StructMember('Hello world!', [myVarMyStrDefinition]),
                 }))
             ]);
         });
@@ -583,7 +583,7 @@ describe('evaluator', () => {
                 1,
                 1,
                 Struct.from(Object.entries({
-                    A: new StructMember(1, myVarADefinition),
+                    A: new StructMember(1, [myVarADefinition]),
                 }))
             ]);
         });
@@ -607,8 +607,8 @@ describe('evaluator', () => {
                 2,
                 2,
                 Struct.from(Object.entries({
-                    A1: new StructMember(1, myVarA1Definition),
-                    A2: new StructMember(2, myVarA2Definition),
+                    A1: new StructMember(1, [myVarA1Definition]),
+                    A2: new StructMember(2, [myVarA2Definition]),
                 }))
             ]);
         });
@@ -623,7 +623,7 @@ describe('evaluator', () => {
             assertEvaluatedVariablesValueEqual(input, [
                 ['a', 'b', 'c'],
                 Struct.from(Object.entries({
-                    MyArray: new StructMember(['a', 'b', 'c'], myVarMyArrayDefinition),
+                    MyArray: new StructMember(['a', 'b', 'c'], [myVarMyArrayDefinition]),
                 }))
             ]);
         });
@@ -639,13 +639,13 @@ describe('evaluator', () => {
             const myVarMyStructMyIntDefinition: VariableDefinition = { id: 1, range: createRange(3, 24, 3, 30), name: 'MyInt' };
             const myVarMyStructDefinition: VariableDefinition = { id: 2, range: createRange(2, 20, 2, 29), name: 'MyStruct' };
             const expectedMyStructValue = Struct.from(Object.entries({
-                MyInt: new StructMember(1, myVarMyStructMyIntDefinition),
+                MyInt: new StructMember(1, [myVarMyStructMyIntDefinition]),
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 1,
                 expectedMyStructValue,
                 Struct.from(Object.entries({
-                    MyStruct: new StructMember(expectedMyStructValue, myVarMyStructDefinition),
+                    MyStruct: new StructMember(expectedMyStructValue, [myVarMyStructDefinition]),
                 }))
             ]);
         });
@@ -664,24 +664,24 @@ describe('evaluator', () => {
             assertEvaluatedVariablesValueEqual(input, [
                 1,
                 Struct.from(Object.entries({
-                    MyInt: new StructMember(1, struct1MyIntDefinition),
+                    MyInt: new StructMember(1, [struct1MyIntDefinition]),
                 })),
                 2,
                 Struct.from(Object.entries({
-                    MyInt: new StructMember(2, struct2MyIntDefinition),
+                    MyInt: new StructMember(2, [struct2MyIntDefinition]),
                 })),
                 Struct.from(Object.entries({
-                    MyInt: new StructMember(1, struct1MyIntDefinition),
+                    MyInt: new StructMember(1, [struct1MyIntDefinition]),
                 })),
                 Struct.from(Object.entries({
-                    MyInt: new StructMember(2, struct2MyIntDefinition),
+                    MyInt: new StructMember(2, [struct2MyIntDefinition]),
                 })),
                 [
                     Struct.from(Object.entries({
-                        MyInt: new StructMember(1, struct1MyIntDefinition),
+                        MyInt: new StructMember(1, [struct1MyIntDefinition]),
                     })),
                     Struct.from(Object.entries({
-                        MyInt: new StructMember(2, struct2MyIntDefinition),
+                        MyInt: new StructMember(2, [struct2MyIntDefinition]),
                     })),
                 ]
             ]);
@@ -1069,7 +1069,7 @@ describe('evaluator', () => {
                 'hello',
                 'hello world',
                 Struct.from(Object.entries({
-                    MyMessage: new StructMember('hello world', myStructMyMessageDefinition),
+                    MyMessage: new StructMember('hello world', [myStructMyMessageDefinition]),
                 })),
                 'hello',
             ]);
@@ -1154,14 +1154,14 @@ describe('evaluator', () => {
             const struct1ADefinition: VariableDefinition = { id: 1, range: createRange(2, 20, 2, 22), name: 'A' };
             const struct1BDefinition: VariableDefinition = { id: 2, range: createRange(3, 20, 3, 22), name: 'B' };
             const struct1 = Struct.from(Object.entries({
-                A: new StructMember(0, struct1ADefinition),
-                B: new StructMember(2, struct1BDefinition),
+                A: new StructMember(0, [struct1ADefinition]),
+                B: new StructMember(2, [struct1BDefinition]),
             }));
             const struct2ADefinition: VariableDefinition = { id: 4, range: createRange(6, 20, 6, 22), name: 'A' };
             const struct2CDefinition: VariableDefinition = { id: 5, range: createRange(7, 20, 7, 22), name: 'C' };
             const struct2 = Struct.from(Object.entries({
-                A: new StructMember(1, struct2ADefinition),
-                C: new StructMember(3, struct2CDefinition),
+                A: new StructMember(1, [struct2ADefinition]),
+                C: new StructMember(3, [struct2CDefinition]),
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 0,
@@ -1173,9 +1173,9 @@ describe('evaluator', () => {
                 struct1,
                 struct2,
                 Struct.from(Object.entries({
-                    A: new StructMember(1, struct2ADefinition),
-                    B: new StructMember(2, struct1BDefinition),
-                    C: new StructMember(3, struct2CDefinition),
+                    A: new StructMember(1, [struct2ADefinition]),
+                    B: new StructMember(2, [struct1BDefinition]),
+                    C: new StructMember(3, [struct2CDefinition]),
                 }))
             ]);
         });
@@ -2049,9 +2049,9 @@ describe('evaluator', () => {
             const myStructMyIntDefinition: VariableDefinition = { id: 3, range: createRange(4, 20, 4, 26), name: 'MyInt' };
             const myStructMyStringDefinition: VariableDefinition = { id: 4, range: createRange(5, 20, 5, 29), name: 'MyString' };
             const myStruct = Struct.from(Object.entries({
-                MyBool: new StructMember(true, myStructMyBoolDefinition),
-                MyInt: new StructMember(1, myStructMyIntDefinition),
-                MyString: new StructMember('hello', myStructMyStringDefinition)
+                MyBool: new StructMember(true, [myStructMyBoolDefinition]),
+                MyInt: new StructMember(1, [myStructMyIntDefinition]),
+                MyString: new StructMember('hello', [myStructMyStringDefinition]),
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 false,
@@ -2089,16 +2089,16 @@ describe('evaluator', () => {
             const usingMyStructMyStringDefinition: VariableDefinition = { id: 9, range: usingMyStructRange, name: 'MyString' };
             const usingMyStructMyEvaluatedVarDefinition: VariableDefinition = { id: 10, range: usingMyStructRange, name: 'MyEvaluatedVar' };
             const myStruct = Struct.from(Object.entries({
-                MyBool: new StructMember(true, myStructMyBoolDefinition),
-                MyInt: new StructMember(1, myStructMyIntDefinition),
-                MyString: new StructMember('hello', myStructMyStringDefinition),
-                MyEvaluatedVar: new StructMember('fun', myStructMyEvaluatedVarDefinition)
+                MyBool: new StructMember(true, [myStructMyBoolDefinition]),
+                MyInt: new StructMember(1, [myStructMyIntDefinition]),
+                MyString: new StructMember('hello', [myStructMyStringDefinition]),
+                MyEvaluatedVar: new StructMember('fun', [myStructMyEvaluatedVarDefinition]),
             }));
             const other = Struct.from(Object.entries({
-                MyBool: new StructMember(true, usingMyStructMyBoolDefinition),
-                MyInt: new StructMember(1, usingMyStructMyIntDefinition),
-                MyString: new StructMember('hello', usingMyStructMyStringDefinition),
-                MyEvaluatedVar: new StructMember('fun', usingMyStructMyEvaluatedVarDefinition)
+                MyBool: new StructMember(true, [usingMyStructMyBoolDefinition]),
+                MyInt: new StructMember(1, [usingMyStructMyIntDefinition]),
+                MyString: new StructMember('hello', [usingMyStructMyStringDefinition]),
+                MyEvaluatedVar: new StructMember('fun', [usingMyStructMyEvaluatedVarDefinition]),
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 'fun',
@@ -2194,10 +2194,10 @@ describe('evaluator', () => {
             const usingMyStruct1MyIntDefinition: VariableDefinition = { id: 3, range: createRange(5, 20, 5, 39), name: 'MyInt' };
             const usingMyStruct2MyIntDefinition: VariableDefinition = { id: 5, range: createRange(8, 20, 8, 39), name: 'MyInt' };
             const myStruct1 = Struct.from(Object.entries({
-                MyInt: new StructMember(1, myStruct1MyIntDefinition),
+                MyInt: new StructMember(1, [myStruct1MyIntDefinition]),
             }));
             const myStruct2 = Struct.from(Object.entries({
-                MyInt: new StructMember(1, usingMyStruct1MyIntDefinition),
+                MyInt: new StructMember(1, [usingMyStruct1MyIntDefinition]),
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 1,
@@ -2211,7 +2211,7 @@ describe('evaluator', () => {
                 myStruct2,
                 // .MyStruct3 = ...
                 Struct.from(Object.entries({
-                    MyInt: new StructMember(1, usingMyStruct2MyIntDefinition),
+                    MyInt: new StructMember(1, [usingMyStruct2MyIntDefinition]),
                 }))
             ]);
         });
@@ -2239,7 +2239,7 @@ describe('evaluator', () => {
             `;
             const myStructStructVar1Definition: VariableDefinition = { id: 1, range: createRange(3, 20, 3, 31), name: 'StructVar1' };
             const myStruct = Struct.from(Object.entries({
-                StructVar1: new StructMember(1, myStructStructVar1Definition)
+                StructVar1: new StructMember(1, [myStructStructVar1Definition])
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 1,
@@ -2317,10 +2317,10 @@ describe('evaluator', () => {
             const myStruct1ValueDefinition: VariableDefinition = { id: 1, range: createRange(1, 31, 1, 37), name: 'Value' };
             const myStruct2ValueDefinition: VariableDefinition = { id: 3, range: createRange(2, 31, 2, 37), name: 'Value' };
             const myStruct1 = Struct.from(Object.entries({
-                Value: new StructMember(1, myStruct1ValueDefinition)
+                Value: new StructMember(1, [myStruct1ValueDefinition])
             }));
             const myStruct2 = Struct.from(Object.entries({
-                Value: new StructMember(2, myStruct2ValueDefinition)
+                Value: new StructMember(2, [myStruct2ValueDefinition])
             }));
             assertEvaluatedVariablesValueEqual(input, [
                 // .Value = 1
@@ -5048,9 +5048,9 @@ Expecting to see the following:
                 2,
                 3,
                 Struct.from(Object.entries({
-                    A: new StructMember(1, myVarADefinition),
-                    B: new StructMember(2, myVarBDefinition),
-                    C: new StructMember(3, myVarCDefinition),
+                    A: new StructMember(1, [myVarADefinition]),
+                    B: new StructMember(2, [myVarBDefinition]),
+                    C: new StructMember(3, [myVarCDefinition]),
                 }))
             ]);
         });

--- a/server/src/test/3-hoversProvider.test.ts
+++ b/server/src/test/3-hoversProvider.test.ts
@@ -112,8 +112,8 @@ describe('hoversProvider', () => {
         it('works for a struct', () => {
             const dummyDefinition: VariableDefinition = { id: 1, range: createRange('file:///dummy.bff', 0, 0, 0, 0), name: '' };
             const value = Struct.from(Object.entries({
-                A: new StructMember(1, dummyDefinition),
-                B: new StructMember(2, dummyDefinition)
+                A: new StructMember(1, [dummyDefinition]),
+                B: new StructMember(2, [dummyDefinition]),
             }));
             const str = valueToString(value);
             assert.strictEqual(
@@ -128,13 +128,13 @@ describe('hoversProvider', () => {
             const dummyDefinition: VariableDefinition = { id: 1, range: createRange('file:///dummy.bff', 0, 0, 0, 0), name: '' };
             const value = Struct.from(Object.entries({
                 A: new StructMember(Struct.from(Object.entries({
-                    A1: new StructMember(1, dummyDefinition),
-                    A2: new StructMember(2, dummyDefinition)
-                })), dummyDefinition),
+                    A1: new StructMember(1, [dummyDefinition]),
+                    A2: new StructMember(2, [dummyDefinition]),
+                })), [dummyDefinition]),
                 B: new StructMember(Struct.from(Object.entries({
-                    B1: new StructMember(1, dummyDefinition),
-                    B2: new StructMember(2, dummyDefinition)
-                })), dummyDefinition)
+                    B1: new StructMember(1, [dummyDefinition]),
+                    B2: new StructMember(2, [dummyDefinition]),
+                })), [dummyDefinition]),
             }));
             const str = valueToString(value);
             assert.strictEqual(
@@ -204,7 +204,7 @@ Values:
         it('deduplicates identical struct values', () => {
             const dummyDefinition: VariableDefinition = { id: 1, range: createRange('file:///dummy.bff', 0, 0, 0, 0), name: '' };
             const value = Struct.from(Object.entries({
-                A: new StructMember(1, dummyDefinition),
+                A: new StructMember(1, [dummyDefinition]),
             }));
 
             const actualHoverText = getHoverText([

--- a/server/src/test/4-referenceProvider.test.ts
+++ b/server/src/test/4-referenceProvider.test.ts
@@ -71,10 +71,10 @@ describe('referenceProvider', () => {
             const actualReferences = getReferences(input, lookupPosition);
 
             const expectedReferences: Location[] = [
-                // The definition of A in `Using( .MyStruct )`
-                createLocation(4, 16, 34),
                 // The `.A` in `.A = 1`
                 createLocation(2, 20, 22),
+                // The definition of A in `Using( .MyStruct )`
+                createLocation(4, 16, 34),
                 // The `.A` in `Print( .A )`
                 createLocation(5, 23, 25),
             ];
@@ -140,14 +140,14 @@ describe('referenceProvider', () => {
             const actualReferences = getReferences(input, lookupPosition);
 
             const expectedReferences: Location[] = [
-                // The definition of A in `Using( .MyStruct )`
-                createLocation(16, 20, 38),
                 // The `.A` in `.A = 1`
                 createLocation(2, 20, 22),
-                // The `.A` in `Print( .A )`
-                createLocation(17, 27, 29),
                 // The `.A` in `.A = 2`
                 createLocation(6, 20, 22),
+                // The definition of A in `Using( .MyStruct )`
+                createLocation(16, 20, 38),
+                // The `.A` in `Print( .A )`
+                createLocation(17, 27, 29),
             ];
 
             assert.deepStrictEqual(actualReferences, expectedReferences);

--- a/server/src/test/5-definitionProvider.test.ts
+++ b/server/src/test/5-definitionProvider.test.ts
@@ -83,6 +83,28 @@ describe('definitionProvider', () => {
             assert.deepStrictEqual(actualReferences, expectedDefinitions);
         });
 
+        it('multiple variables at the same position', () => {
+            const input = `
+                .A_B_C = 'foo'
+                .Middle = 'B'
+                Print( ."A_$Middle$_C" )
+            `;
+            // The position of the first `$` in `Print( ."A_$Middle$_C" )`
+            const lookupPosition = Position.create(3, 27);
+            const actualReferences = getDefinition(input, lookupPosition);
+
+            const expectedDefinitions: DefinitionLink[] = [
+                // Reference: the `$Middle$` in `Print( ."A_$Middle$_C" )`
+                // Definition: the `.Middle` in `.Middle = 'B'`
+                createDefinition(createRange(3, 27, 35), createRange(2, 16, 23)),
+                // Reference: the `."A_$Middle$_C"` in `Print( ."A_$Middle$_C" )`
+                // Definition: the `.A_B_C` in `.A_B_C = 'foo'`
+                createDefinition(createRange(3, 23, 38), createRange(1, 16, 22)),
+            ];
+
+            assert.deepStrictEqual(actualReferences, expectedDefinitions);
+        });
+
         it('struct field defined from a `Using`', () => {
             const input = `
                 .MyStruct = [
@@ -99,6 +121,9 @@ describe('definitionProvider', () => {
                 // Reference: the `.A` in `Print( .A )`
                 // Definition: `Using( .MyStruct )`
                 createDefinition(createRange(5, 23, 25), createRange(4, 16, 34)),
+                // Reference: the `.A` in `Print( .A )`
+                // Definition: the `.A` in `.A = 1`
+                createDefinition(createRange(5, 23, 25), createRange(2, 20, 22)),
             ];
 
             assert.deepStrictEqual(actualReferences, expectedDefinitions);
@@ -133,6 +158,12 @@ describe('definitionProvider', () => {
                 // Reference: the `.A` in `Print( .A )`
                 // Definition: `Using( .MyStruct )`
                 createDefinition(createRange(17, 27, 29), createRange(16, 20, 38)),
+                // Reference: the `.A` in `Print( .A )`
+                // Definition: the `.A` in `.A = 1`
+                createDefinition(createRange(17, 27, 29), createRange(2, 21, 22)),
+                // Reference: the `.A` in `Print( .A )`
+                // Definition: the `.A` in `.A = 2`
+                createDefinition(createRange(17, 27, 29), createRange(6, 21, 22)),
             ];
 
             assert.deepStrictEqual(actualReferences, expectedDefinitions);

--- a/server/src/test/5-definitionProvider.test.ts
+++ b/server/src/test/5-definitionProvider.test.ts
@@ -83,6 +83,27 @@ describe('definitionProvider', () => {
             assert.deepStrictEqual(actualReferences, expectedDefinitions);
         });
 
+        it('variable defined in a loop', () => {
+            const input = `
+                .Items = { 'a', 'b' }
+                ForEach( .A in .Items )
+                {
+                    Print( .A )
+                }
+            `;
+            // The position of the `.` in `Print( .A )`
+            const lookupPosition = Position.create(4, 27);
+            const actualReferences = getDefinition(input, lookupPosition);
+
+            const expectedDefinitions: DefinitionLink[] = [
+                // Reference: the `.A` in `Print( .A )`
+                // Definition: the `.A` in `ForEach( .A in .Items )`
+                createDefinition(createRange(4, 27, 29), createRange(2, 25, 27)),
+            ];
+
+            assert.deepStrictEqual(actualReferences, expectedDefinitions);
+        });
+
         it('multiple variables at the same position', () => {
             const input = `
                 .A_B_C = 'foo'
@@ -105,7 +126,7 @@ describe('definitionProvider', () => {
             assert.deepStrictEqual(actualReferences, expectedDefinitions);
         });
 
-        it('struct field defined from a `Using`', () => {
+        it('struct field variable defined from a `Using`', () => {
             const input = `
                 .MyStruct = [
                     .A = 1
@@ -129,7 +150,7 @@ describe('definitionProvider', () => {
             assert.deepStrictEqual(actualReferences, expectedDefinitions);
         });
 
-        it('struct field defined from a `Using` in a `ForEach`', () => {
+        it('struct field variable defined from a `Using` in a `ForEach`', () => {
             const input = `
                 .MyStruct1 = [
                     .A = 1

--- a/server/src/test/5-definitionProvider.test.ts
+++ b/server/src/test/5-definitionProvider.test.ts
@@ -140,11 +140,11 @@ describe('definitionProvider', () => {
 
             const expectedDefinitions: DefinitionLink[] = [
                 // Reference: the `.A` in `Print( .A )`
-                // Definition: `Using( .MyStruct )`
-                createDefinition(createRange(5, 23, 25), createRange(4, 16, 34)),
-                // Reference: the `.A` in `Print( .A )`
                 // Definition: the `.A` in `.A = 1`
                 createDefinition(createRange(5, 23, 25), createRange(2, 20, 22)),
+                // Reference: the `.A` in `Print( .A )`
+                // Definition: `Using( .MyStruct )`
+                createDefinition(createRange(5, 23, 25), createRange(4, 16, 34)),
             ];
 
             assert.deepStrictEqual(actualReferences, expectedDefinitions);
@@ -177,14 +177,14 @@ describe('definitionProvider', () => {
 
             const expectedDefinitions: DefinitionLink[] = [
                 // Reference: the `.A` in `Print( .A )`
+                // Definition: the `.A` in `.A = 1`
+                createDefinition(createRange(17, 27, 29), createRange(2, 20, 22)),
+                // Reference: the `.A` in `Print( .A )`
                 // Definition: `Using( .MyStruct )`
                 createDefinition(createRange(17, 27, 29), createRange(16, 20, 38)),
                 // Reference: the `.A` in `Print( .A )`
-                // Definition: the `.A` in `.A = 1`
-                createDefinition(createRange(17, 27, 29), createRange(2, 21, 22)),
-                // Reference: the `.A` in `Print( .A )`
                 // Definition: the `.A` in `.A = 2`
-                createDefinition(createRange(17, 27, 29), createRange(6, 21, 22)),
+                createDefinition(createRange(17, 27, 29), createRange(6, 20, 22)),
             ];
 
             assert.deepStrictEqual(actualReferences, expectedDefinitions);


### PR DESCRIPTION
Internally, this changes variable references to support having multiple definitions.

Fixes #54.