### PR TITLE
Stop unnecessarily re-parsing and re-evaluating when holding `Ctrl`  (the go-to-definition hotkey) and hovering over a reference whose definition is in an unopened file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Performance improvements
 
-* ([#59](https://github.com/harrisont/fastbuild-vscode/issues/59)) Stop unnecessarily re-parsing and re-evaluating when holding `Ctrl` and hovering over a variable/include whose definition is in an unopened file.
+* ([#59](https://github.com/harrisont/fastbuild-vscode/issues/59)) Stop unnecessarily re-parsing and re-evaluating when holding `Ctrl`  (the go-to-definition hotkey) and hovering over a variable/include whose definition is in an unopened file. This significantly improves performance in these scenarios.
 
 # v0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.10.2
+
+## Performance improvements
+
+* ([#59](https://github.com/harrisont/fastbuild-vscode/issues/59)) Stop unnecessarily re-parsing and re-evaluating when holding `Ctrl` and hovering over a variable/include whose definition is in an unopened file.
+
 # v0.10.1
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/parseDataProvider.ts
+++ b/server/src/parseDataProvider.ts
@@ -69,17 +69,6 @@ export class ParseDataProvider {
         }
     }
 
-    // The same as `updateParseDataWithContent`, but skips re-parsing if the content is the same
-    // as the cached content.
-    updateParseDataWithContentIfChanged(uri: vscodeUri.URI, content: string): Maybe<ParseData>  {
-        const cachedData = this.data.get(uri.toString());
-        if (cachedData !== undefined && content === cachedData.fileContent) {
-            return Maybe.ok(cachedData.data);
-        } else {
-            return this.updateParseDataWithContent(uri, content);
-        }
-    }
-
     // Returns the parse data for a URI.
     // If the data is already cached, it just returns it, even if the cached data is stale.
     // Otherwise, it calculates the parse data and caches it.
@@ -92,6 +81,16 @@ export class ParseDataProvider {
             return this.updateParseData(uri);
         } else {
             return Maybe.ok(cachedData.data);
+        }
+    }
+
+    // Returns the cached content for a URI if it exists, or `null` otherwise.
+    getCachedDocumentContent(uri: vscodeUri.URI): string | null {
+        const cachedData = this.data.get(uri.toString());
+        if (cachedData === undefined) {
+            return null;
+        } else {
+            return cachedData.fileContent;
         }
     }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -238,6 +238,12 @@ state.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams) => {
 });
 
 // The content of a file has changed. This event is emitted when the file first opened or when its content has changed.
+//
+// Note that it also can occur when holding 'Ctrl' (the go-to-definition hotkey) and hovering over a reference
+// whose definition is in an unopened file.
+// In this case, VS Code opens and closes that file, which triggers this `onDidChangeContent` event even though
+// no content changed.
+// See [#59](https://github.com/harrisont/fastbuild-vscode/issues/59) for details.
 state.documents.onDidChangeContent(change => {
     queueDocumentUpdate(change);
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import {
     InitializeResult,
     ProposedFeatures,
     ReferenceParams,
+    TextDocumentChangeEvent,
     TextDocuments,
     TextDocumentSyncKind,
     WorkspaceSymbolParams,
@@ -239,13 +240,14 @@ state.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams) => {
 // The content of a file has changed. This event is emitted when the file first opened or when its content has changed.
 state.documents.onDidChangeContent(change => {
     console.log(`REMOVE BEFORE MERGE: onDidChangeContent: uri="${change.document.uri}", content=${JSON.stringify(change.document.getText())}`);
-    queueDocumentUpdate(change.document.uri);
+    queueDocumentUpdate(change);
 });
 
 // Wait for a period of time before updating.
 // This improves the performance when the user is rapidly modifying the document (e.g. typing),
 // at the cost of introducing a small amount of latency.
-async function queueDocumentUpdate(documentUriStr: UriStr): Promise<void> {
+async function queueDocumentUpdate(change: TextDocumentChangeEvent<TextDocument>): Promise<void> {
+    const documentUriStr = change.document.uri;
     const settings = await state.getSettings();
 
     // Cancel any existing queued update.
@@ -255,7 +257,7 @@ async function queueDocumentUpdate(documentUriStr: UriStr): Promise<void> {
         state.queuedDocumentUpdates.delete(documentUriStr);
     }
 
-    const updateFunction = () => updateDocument(documentUriStr, settings);
+    const updateFunction = () => updateDocument(change, settings);
 
     // Skip the delay and immediately update if the document has no evaulated data.
     // This is necesasry in order to do initially populate the data.
@@ -286,7 +288,8 @@ function flushQueuedDocumentUpdates() {
     state.queuedDocumentUpdates.clear();
 }
 
-function updateDocument(changedDocumentUriStr: UriStr, settings: Settings): void {
+function updateDocument(change: TextDocumentChangeEvent<TextDocument>, settings: Settings): void {
+    const changedDocumentUriStr = change.document.uri;
     const changedDocumentUri = vscodeUri.URI.parse(changedDocumentUriStr);
 
     let evaluatedData = new EvaluatedData();
@@ -306,7 +309,7 @@ function updateDocument(changedDocumentUriStr: UriStr, settings: Settings): void
         if (settings.logPerformanceMetrics) {
             console.time(parseDurationLabel);
         }
-        const maybeChangedDocumentParseData = state.parseDataProvider.updateParseData(changedDocumentUri);
+        const maybeChangedDocumentParseData = state.parseDataProvider.updateParseDataWithContentIfChanged(changedDocumentUri, change.document.getText());
         if (maybeChangedDocumentParseData.hasError) {
             if (settings.logPerformanceMetrics) {
                 console.timeEnd(parseDurationLabel);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -239,7 +239,6 @@ state.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams) => {
 
 // The content of a file has changed. This event is emitted when the file first opened or when its content has changed.
 state.documents.onDidChangeContent(change => {
-    console.log(`REMOVE BEFORE MERGE: onDidChangeContent: uri="${change.document.uri}", content=${JSON.stringify(change.document.getText())}`);
     queueDocumentUpdate(change);
 });
 
@@ -308,7 +307,7 @@ function updateDocument(change: TextDocumentChangeEvent<TextDocument>, settings:
         const cachedEvaluatedData = state.rootToEvaluatedDataMap.get(rootFbuildUriStr);
         const changedDocumentContent = change.document.getText();
         const cachedDocumentContent = state.parseDataProvider.getCachedDocumentContent(changedDocumentUri);
-        if (cachedEvaluatedData !== undefined && cachedDocumentContent == changedDocumentContent) {
+        if (cachedEvaluatedData !== undefined && changedDocumentContent === cachedDocumentContent) {
             return;
         }
 
@@ -369,8 +368,6 @@ function updateDocument(change: TextDocumentChangeEvent<TextDocument>, settings:
 
 // Track the open files by root FASTBuild file.
 state.documents.onDidOpen(change => {
-    console.log(`REMOVE BEFORE MERGE: onDidOpen: uri="${change.document.uri}", content=${JSON.stringify(change.document.getText())}`);
-
     const changedDocumentUriStr: UriStr = change.document.uri;
     const changedDocumentUri = vscodeUri.URI.parse(changedDocumentUriStr);
     const rootFbuildUri = state.getRootFbuildFile(changedDocumentUri);
@@ -381,8 +378,6 @@ state.documents.onDidOpen(change => {
 
 // If the closed document's root's tree has no more open documents, clear state for the root.
 state.documents.onDidClose(change => {
-    console.log(`REMOVE BEFORE MERGE: onDidClose: uri="${change.document.uri}"`);
-
     const closedDocumentUriStr: UriStr = change.document.uri;
     const rootFbuildUriStr = state.openDocumentToRootMap.get(closedDocumentUriStr);
     if (rootFbuildUriStr === undefined) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -237,7 +237,10 @@ state.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams) => {
 });
 
 // The content of a file has changed. This event is emitted when the file first opened or when its content has changed.
-state.documents.onDidChangeContent(change => queueDocumentUpdate(change.document.uri));
+state.documents.onDidChangeContent(change => {
+    console.log(`REMOVE BEFORE MERGE: onDidChangeContent: uri="${change.document.uri}", content=${JSON.stringify(change.document.getText())}`);
+    queueDocumentUpdate(change.document.uri);
+});
 
 // Wait for a period of time before updating.
 // This improves the performance when the user is rapidly modifying the document (e.g. typing),
@@ -356,6 +359,8 @@ function updateDocument(changedDocumentUriStr: UriStr, settings: Settings): void
 
 // Track the open files by root FASTBuild file.
 state.documents.onDidOpen(change => {
+    console.log(`REMOVE BEFORE MERGE: onDidOpen: uri="${change.document.uri}", content=${JSON.stringify(change.document.getText())}`);
+
     const changedDocumentUriStr: UriStr = change.document.uri;
     const changedDocumentUri = vscodeUri.URI.parse(changedDocumentUriStr);
     const rootFbuildUri = state.getRootFbuildFile(changedDocumentUri);
@@ -366,6 +371,8 @@ state.documents.onDidOpen(change => {
 
 // If the closed document's root's tree has no more open documents, clear state for the root.
 state.documents.onDidClose(change => {
+    console.log(`REMOVE BEFORE MERGE: onDidClose: uri="${change.document.uri}"`);
+
     const closedDocumentUriStr: UriStr = change.document.uri;
     const rootFbuildUriStr = state.openDocumentToRootMap.get(closedDocumentUriStr);
     if (rootFbuildUriStr === undefined) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -305,11 +305,18 @@ function updateDocument(change: TextDocumentChangeEvent<TextDocument>, settings:
         }
         rootFbuildUriStr = rootFbuildUri.toString();
 
+        const cachedEvaluatedData = state.rootToEvaluatedDataMap.get(rootFbuildUriStr);
+        const changedDocumentContent = change.document.getText();
+        const cachedDocumentContent = state.parseDataProvider.getCachedDocumentContent(changedDocumentUri);
+        if (cachedEvaluatedData !== undefined && cachedDocumentContent == changedDocumentContent) {
+            return;
+        }
+
         const parseDurationLabel = 'parse-duration';
         if (settings.logPerformanceMetrics) {
             console.time(parseDurationLabel);
         }
-        const maybeChangedDocumentParseData = state.parseDataProvider.updateParseDataWithContentIfChanged(changedDocumentUri, change.document.getText());
+        const maybeChangedDocumentParseData = state.parseDataProvider.updateParseDataWithContent(changedDocumentUri, changedDocumentContent);
         if (maybeChangedDocumentParseData.hasError) {
             if (settings.logPerformanceMetrics) {
                 console.timeEnd(parseDurationLabel);


### PR DESCRIPTION
This significantly improves performance in these scenarios.

Fixes #59.