### PR TITLE
Support jumping to the existing definition for redefinition errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.11.0
+
+## New Features
+
+* ([#64](https://github.com/harrisont/fastbuild-vscode/issues/64)) Support jumping to the existing definition for redefinition errors. Supports `#define`s, target aliases, and user-function names.
+
 # v0.10.2
 
 ## Performance improvements

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.10.2",
+	"version": "0.11.0",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -306,7 +306,7 @@ function updateDocument(change: TextDocumentChangeEvent<TextDocument>, settings:
         const rootFbuildUri = state.getRootFbuildFile(changedDocumentUri);
         if (rootFbuildUri === null) {
             const errorRange = SourceRange.create(changedDocumentUriStr, 0, 0, Number.MAX_VALUE, Number.MAX_VALUE);
-            throw new EvaluationError(errorRange, `Could not find a root FASTBuild file ('${ROOT_FBUILD_FILE}') for document '${changedDocumentUri.fsPath}'`);
+            throw new EvaluationError(errorRange, `Could not find a root FASTBuild file ('${ROOT_FBUILD_FILE}') for document '${changedDocumentUri.fsPath}'`, []);
         }
         rootFbuildUriStr = rootFbuildUri.toString();
 


### PR DESCRIPTION
Supports `#define`s, target aliases, and user-function names.
Fixes #64.

Before:
![image](https://user-images.githubusercontent.com/144260/235365254-5f3d734e-1d8d-4a5e-ab72-77219c638c94.png)

After:
![image](https://user-images.githubusercontent.com/144260/235365219-21d9245f-92a7-4ff9-bb44-96ba88f04843.png)

