### PR TITLE
Fix the errors not updated when changing a file to introduce a parse error and then undoing that change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.13.1
+
+## Bug Fixes
+
+* ([#67](https://github.com/harrisont/fastbuild-vscode/issues/67)) Fix the errors not updated when changing a file to introduce a parse error and then undoing that change.
+
 # v0.13.0
 
 ## New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/parseDataProvider.ts
+++ b/server/src/parseDataProvider.ts
@@ -58,6 +58,7 @@ export class ParseDataProvider {
             });
             return Maybe.ok(parseData);
         } catch (error) {
+            this.data.delete(uri.toString());
             if (error instanceof Error) {
                 return Maybe.error(error);
             } else {


### PR DESCRIPTION
Fixes #67