### PR TITLE
Fix the bug where a period in a variable name generates a syntax error when using it in a string template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.13.4
+
+## Bug Fixes
+
+* ([#71](https://github.com/harrisont/fastbuild-vscode/issues/71)) Fix the bug where a period in a variable name generates a syntax error when using it in a string template.
+
 # v0.13.3
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/fbuild-grammar.ne
+++ b/server/src/fbuild-grammar.ne
@@ -120,7 +120,7 @@ const lexer = moo.states({
     },
     templatedVariable: {
         endTemplatedVariable: { match: '$', pop: 1 },
-        variableName: /[a-zA-Z_][a-zA-Z0-9_]*/,
+        variableName: /[a-zA-Z_.][a-zA-Z0-9_.]*/,
     },
     variableReferenceName: {
         // Literal variable name

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -207,6 +207,14 @@ describe('evaluator', () => {
             assertEvaluatedVariablesValueEqual(input, [1, 1, 1]);
         });
 
+        it('should be detected in the RHS when assigning the value of another variable whose name contains a period', () => {
+            const input = `
+                .'My.Var' = 1
+                .Copy = .'My.Var'
+            `;
+            assertEvaluatedVariablesValueEqual(input, [1, 1, 1]);
+        });
+
         it('should be detected in the RHS when assigning the value of another variable in the parent scope', () => {
             const input = `
                 .MyVar = 1

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -182,6 +182,14 @@ describe('evaluator', () => {
             assertEvaluatedVariablesValueEqual(input, ['MyValue', 'MyValue']);
         });
 
+        it('should be detected in a string with a variable whose name contains a period', () => {
+            const input = `
+                .'My.Var' = 'MyValue'
+                Print('pre-$My.Var$-post')
+            `;
+            assertEvaluatedVariablesValueEqual(input, ['MyValue', 'MyValue']);
+        });
+
         it('should be detected in a string with multiple variables', () => {
             const input = `
                 .MyVar1 = 'MyValue1'

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -741,6 +741,21 @@ describe('evaluator', () => {
             ]);
         });
 
+        it('should evaluate dynamic variable names with periods in them on the RHS in the current scope', () => {
+            const input = `
+                .A_B_C = 'foo'
+                .'Mid.dle' = 'B'
+                .MyVar = ."A_$Mid.dle$_C"
+            `;
+            assertEvaluatedVariablesValueEqual(input, [
+                'foo',
+                'B',
+                'B',
+                'foo',
+                'foo',
+            ]);
+        });
+
         it('should evaluate dynamic variable names on the RHS in the parent scope', () => {
             const input = `
                 .A_B_C = 'foo'


### PR DESCRIPTION
Fixes #71 