### PR TITLE
Fix the syntax highlighting when using a period in a variable name when using it in a string template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.14.1
+
+## Bug Fixes
+
+* ([#71](https://github.com/harrisont/fastbuild-vscode/issues/71)) Fix the syntax highlighting when using a period in a variable name when using it in a string template.
+
 # v0.14.0
 
 ## New Features

--- a/fastbuild.tmLanguage.json
+++ b/fastbuild.tmLanguage.json
@@ -76,7 +76,7 @@
 			"patterns": [
 				{
 					"name": "constant.character.escape.fastbuild",
-					"match": "\\^.|\\$[\\w]+\\$|%\\d+"
+					"match": "\\^.|\\$[\\w\\.]+\\$|%\\d+"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {


### PR DESCRIPTION
Related to the fix for #71.
#71 (already fixed) tracked the syntax error for this pattern.
This fixes the syntax highlighting for the pattern.