### PR TITLE
Support FASTBuild v1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## New Features
 
-* Increase FASTBuild support from v1.08 to v1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)). Previously the plugin worked for v1.11, but didn't support some features added after v1.08. This includes:
-    * Support for the `_FASTBUILD_VERSION_` builtin variable.
+* Increase FASTBuild support from v1.08 to v1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)). Previously the plugin worked for v1.11, but didn't support every features added after v1.08. Specifically support for the `_FASTBUILD_VERSION_` builtin variable (added in FASTBuild v1.09).
 
 # v0.14.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.14.2
+
+## New Features
+
+* Increase FASTBuild support from v1.08 to v1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)). Previously the plugin worked for v1.11, but didn't support some features added after v1.08. This includes:
+    * Support for the `_FASTBUILD_VERSION_` builtin variable.
+
 # v0.14.1
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-* Increase FASTBuild support from v1.08 to v1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)). Previously the plugin worked for v1.11, but didn't support every features added after v1.08. Specifically support for the `_FASTBUILD_VERSION_` builtin variable (added in FASTBuild v1.09).
+* Increase FASTBuild support from v1.08 to v1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)). Previously the plugin worked for v1.11, but didn't support every features added after v1.08. Specifically support for the `_FASTBUILD_EXE_PATH_` builtin variable (added in FASTBuild v1.09).
 
 # v0.14.1
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Example:
 
 ## Compatibility
 
-Compatible with [FASTBuild](https://www.fastbuild.org/) version 1.08 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)).
+Compatible with [FASTBuild](https://www.fastbuild.org/) version 1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)).
 
 It may be compatible with a newer version of FASTBuild, but this was the latest version tested.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {

--- a/server/src/evaluator.ts
+++ b/server/src/evaluator.ts
@@ -877,6 +877,7 @@ function createDefaultScopeStack(rootFbuildDirUri: vscodeUri.URI): ScopeStack {
     scopeStack.setVariableInCurrentScope('_CURRENT_BFF_DIR_', '', [createNoLocationVariableDefinition('_CURRENT_BFF_DIR_')]);
     scopeStack.setVariableInCurrentScope('_FASTBUILD_VERSION_STRING_', 'vPlaceholderFastBuildVersionString', [createNoLocationVariableDefinition('_FASTBUILD_VERSION_STRING_')]);
     scopeStack.setVariableInCurrentScope('_FASTBUILD_VERSION_', -1, [createNoLocationVariableDefinition('_FASTBUILD_VERSION_')]);
+    scopeStack.setVariableInCurrentScope('_FASTBUILD_EXE_PATH_', 'placeholder-path-to-fastbuild-exe', [createNoLocationVariableDefinition('_FASTBUILD_EXE_PATH_')]);
 
     return scopeStack;
 }

--- a/server/src/test/2-evaluator.test.ts
+++ b/server/src/test/2-evaluator.test.ts
@@ -911,7 +911,7 @@ describe('evaluator', () => {
             ]);
         });
 
-        // We need to use a placeholder because we don't know the actual version of FASTBuild being run.
+        // We need to use a placeholder because we don't know the actual version of FASTBuild executable.
         it('_FASTBUILD_VERSION_STRING_ is a builtin variable that evaluates to (a placeholder for) the current FASTBuild version as a string', () => {
             const input = `
                 Print( ._FASTBUILD_VERSION_STRING_ )
@@ -919,12 +919,20 @@ describe('evaluator', () => {
             assertEvaluatedVariablesValueEqual(input, ['vPlaceholderFastBuildVersionString']);
         });
 
-        // We need to use a placeholder because we don't know the actual version of FASTBuild being run.
+        // We need to use a placeholder because we don't know the actual version of FASTBuild executable.
         it('_FASTBUILD_VERSION_ is a builtin variable that evaluates to (a placeholder for) the current FASTBuild version as an integer', () => {
             const input = `
                 Print( ._FASTBUILD_VERSION_ )
             `;
             assertEvaluatedVariablesValueEqual(input, [-1]);
+        });
+
+        // We need to use a placeholder because we don't know the actual path to the FASTBuild executable.
+        it('_FASTBUILD_EXE_PATH_ is a builtin variable that evaluates to (a placeholder for) the path to the FASTBuild executable', () => {
+            const input = `
+                Print( ._FASTBUILD_EXE_PATH_ )
+            `;
+            assertEvaluatedVariablesValueEqual(input, ['placeholder-path-to-fastbuild-exe']);
         });
     });
 


### PR DESCRIPTION
Increase FASTBuild support from v1.08 to v1.11 ([FASTBuild Changelog](https://www.fastbuild.org/docs/changelog.html)). Previously the plugin worked for v1.11, but didn't support every features added after v1.08. Specifically support for the `_FASTBUILD_EXE_PATH_` builtin variable (added in FASTBuild v1.09).