### PR TITLE
Add root-file setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v0.16.0
+
+## New Features
+
+* ([#82](https://github.com/harrisont/fastbuild-vscode/issues/82)) Add a new optional `Root File` setting to control the FASTBuild root `fbuild.bff` file. The root file normally does not need to be specified in the settings because it is detected automatically when it is in a parent directory. But it is necessary to set when invoking FASTBuild with the `-config <path>` command line option, which overrides the root file.
+
+For example, if you have the following files and run FASTBuild with `fbuild -config <workspace_root>/Projects/fbuild.bff`:
+```
+<workspace_root>/Projects/fbuild.bff
+<workspace_root>/Projects/HelloWorld/HelloWorld.bff
+<workspace_root>/External/MSVC/MSVC.bff
+```
+In this example, `MSVC.bff` by default cannot find the root `fbuild.bff`. So it is necessary to use the `Root File` setting to manually specify the root.
+
 # v0.15.0
 
 ## New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {
@@ -52,7 +52,23 @@
 			"type": "object",
 			"title": "FASTBuild",
 			"properties": {
+				"fastbuild.inputDebounceDelay": {
+					"order": 0,
+					"scope": "window",
+					"type": "number",
+					"minimum": 0,
+					"default": 500,
+					"description": "Delay, in milliseconds, after changing a document before re-evaluating it. A lower value can result in faster feedback, but too low of a value will result in high resource usage when typing quickly."
+				},
+				"fastbuild.rootFile": {
+					"order": 1,
+					"scope": "window",
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Optional absolute path to the root `fbuild.bff` file. Set when running FASTBuild with the `-config <path>` command line option. The root is automatically found when it is in a parent directory, so it is not necessary to specify in that case."
+				},
 				"fastbuild.trace.server": {
+					"order": 2,
 					"scope": "window",
 					"type": "string",
 					"enum": [
@@ -69,17 +85,11 @@
 					"description": "[Extension debugging] Traces the communication between the extension and the language server."
 				},
 				"fastbuild.logPerformanceMetrics": {
+					"order": 3,
 					"scope": "window",
 					"type": "boolean",
 					"default": false,
 					"description": "[Extension debugging] Log performance metrics."
-				},
-				"fastbuild.inputDebounceDelay": {
-					"scope": "window",
-					"type": "number",
-					"minimum": 0,
-					"default": 500,
-					"description": "Delay, in milliseconds, after changing a document before re-evaluating it. A lower value can result in faster feedback, but too low of a value will result in high resource usage when typing quickly."
 				}
 			}
 		}

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// The settings are defined in the root `package.json` under `contributes.configuration`.
+export interface Settings {
+    logPerformanceMetrics: boolean;
+    inputDebounceDelay: number;
+    rootFile: string;
+}
+
+// This indicates that the user set a setting to an invalid value.
+export class SettingsError extends Error {
+    constructor(message: string) {
+        super(message);
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = SettingsError.name;
+    }
+}
+
+export function getRootFileSettingError(rootFile: string): SettingsError | null {
+    if (!rootFile) {
+        return null;
+    }
+
+    if (!path.isAbsolute(rootFile)) {
+        return new SettingsError(`The "Root File" setting is set to "${rootFile}", which is not an absolute file path.`);
+    }
+    
+    try {
+        const rootFileStats = fs.statSync(rootFile);
+        if (!rootFileStats.isFile()) {
+            return new SettingsError(`The "Root File" setting is set to "${rootFile}", which is not a file.`);
+        }
+    } catch (err) {
+        return new SettingsError(`The "Root File" setting is set to "${rootFile}", which does not exist.`);
+    }
+
+    return null;
+}


### PR DESCRIPTION
Add a new optional `Root File` setting to control the FASTBuild root `fbuild.bff` file. The root file normally does not need to be specified in the settings because it is detected automatically when it is in a parent directory. But it is necessary to set when invoking FASTBuild with the `-config <path>` command line option, which overrides the root file.

For example, if you have the following files and run FASTBuild with `fbuild -config <workspace_root>/Projects/fbuild.bff`:
```
<workspace_root>/Projects/fbuild.bff
<workspace_root>/Projects/HelloWorld/HelloWorld.bff
<workspace_root>/External/MSVC/MSVC.bff
```
In this example, `MSVC.bff` by default cannot find the root `fbuild.bff`. So it is necessary to use the `Root File` setting to manually specify the root.

This new setting is the first that the user can set to an invalid value (an invalid path). Handle that by adding settings validation and output of settings-error diagnostics.

This is also the first time that changing a setting can invalidate already-evaluated data. So clear the cached results when the settings change.

Now that getting the root file relies on settings, which arrives async, various other functions need to also become async.

Fixes #82.