### PR TITLE
Fix the `not` in `not in` missing syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.16.1
+
+## Bug Fixes
+
+* ([#85](https://github.com/harrisont/fastbuild-vscode/issues/85)) Fix the `not` in `not in` missing syntax highlighting. The `in` was colored properly but the `not` was not. Thanks to [@xoorath](https://github.com/xoorath) for pointing out this bug.
+
 # v0.16.0
 
 ## New Features

--- a/fastbuild.tmLanguage.json
+++ b/fastbuild.tmLanguage.json
@@ -69,6 +69,10 @@
 				{
 					"name": "keyword.operator.expression.fastbuild",
 					"match": "\\bin\\b"
+				},
+				{
+					"name": "keyword.operator.expression.fastbuild",
+					"match": "\\bnot in\\b"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fastbuild-support",
 	"displayName": "FASTBuild Support",
 	"description": "FASTBuild language support. Includes go-to definition, find references, variable evaluation, syntax errors, etc.",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"preview": true,
 	"publisher": "HarrisonT",
 	"author": {


### PR DESCRIPTION
The `in` was colored properly but the `not` was not.

Fixes #85